### PR TITLE
feat: create-blog-post skill, fix preview locale, bundle social publishing

### DIFF
--- a/.claude/skills/create-blog-post/SKILL.md
+++ b/.claude/skills/create-blog-post/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: create-blog-post
+description: Create a new blog post in Agility CMS from a topic prompt. Writes the post in en-us, then translates it to fr, and uploads a main image. Use when the user asks to write, draft, publish, or create a blog post.
+---
+
+# Create Blog Post (EN → FR, with Image)
+
+Create a complete blog post in Agility CMS from a short topic prompt. The post is authored in English (`en-us`), then translated into French (`fr`), and a main image is uploaded. Both locale versions share the same `contentID`.
+
+## Inputs
+
+- **Topic prompt** — required. A short description of what the post should be about.
+- **Brand guidelines document** — should be attached to the Claude project. Tone, voice, positioning, vocabulary, banned words, CTA patterns, etc. All generated copy MUST follow it.
+- **Image** — required. Either:
+  - An image the user attached to the conversation, OR
+  - A reference image already in the Agility media library (use its existing CDN URL).
+
+If the user has not supplied a brand guidelines document or an image, ask for them before generating anything.
+
+## Target Instance
+
+- **Default `instanceGuid`**: `13f09fe2-u` (project: Demo Site 2026 in the Starter Templates org).
+- Confirm with `mcp__Agility-CMS__get_available_instances` if the user wants a different instance, or if the GUID is rejected.
+- Locales: `en-us` (default) and `fr`. Verify with `mcp__Agility-CMS__get_locales`.
+
+## Content Model: `Post` (container `Posts`)
+
+Fields that matter when saving (names are case-insensitive):
+
+| Field | Type | Notes |
+|---|---|---|
+| `Heading` | Text | Post title. |
+| `Slug` | Text | URL slug — lowercase, hyphenated, ASCII-only, no trailing punctuation. Keep the SAME slug across en-us and fr (slug is not translated). |
+| `PostDate` | Date | ISO date (e.g. `2026-04-21T00:00:00`). Use today's date unless the user specifies otherwise. **If the post is about a past event, use the event date — not today.** |
+| `Category` | LinkedContentDropdown → `Categories` | Pick ONE existing category. See "Linked Content" below. |
+| `CategoryID` | Integer | Companion field. Set to the chosen category's `contentID` as a string. |
+| `CategoryName` | Text | Companion field. Set to the chosen category's `Name`. |
+| `Tags` | LinkedContentSearchListBox → `Tags` | Pick 1–3 existing tags. See "Linked Content" below. |
+| `TagIDs` | Text | Comma-separated `contentID`s of chosen tags (e.g. `"9,8"`). |
+| `TagNames` | Text | Comma-separated `Name`s of chosen tags (e.g. `"Technology,A.I."`). |
+| `Author` | LinkedContentDropdown → `Authors` | Pick ONE existing author. See "Linked Content" below. |
+| `AuthorID` | Integer | Companion field. Set to the author's `contentID` as a string. |
+| `AuthorName` | Text | Companion field. Set to the author's `Name`. |
+| `Content` | Html | Article body as HTML. See "Content Formatting" below. |
+| `Image` | ImageAttachment | Main image. See "Image Handling" below. |
+| `SocialPublishedDate` | Date | **Do NOT set.** Set by the social-publishing webhook automatically. |
+
+The `Category`, `Tags`, and `Author` fields themselves are reference-name strings (e.g. `"categories"`, `"tags"`, `"authors"`) — the actual linking is done through the `*ID` / `*Name` companion fields.
+
+## Workflow
+
+### 1. Gather context
+
+1. Ask the user for the post topic if it wasn't supplied.
+2. Confirm the brand guidelines document is available in the project — if not, ask for it.
+3. Confirm how the image will be provided (attached now vs. pick an existing one).
+
+### 2. Look up linked content (once per session is fine)
+
+Run these in parallel:
+
+- `mcp__Agility-CMS__get_content_items` → `Categories` (locale `en-us`) — pick the best-fit category.
+- `mcp__Agility-CMS__get_content_items` → `Authors` (locale `en-us`) — pick an author. If the user hasn't specified, default to `Joel Varty` (contentID `4`) unless the topic clearly suggests another author from the list.
+- `mcp__Agility-CMS__get_content_items` → `Tags` (locale `en-us`) — pick 1–3 tags that match the topic. Do NOT invent new tags; only choose from existing ones.
+
+Record the `contentID` and `Name` for each selection — you'll need both.
+
+### 3. Draft the English post
+
+Write the post in `en-us`, following the brand guidelines. Requirements:
+
+- **Heading**: Compelling, ≤ 100 chars, aligned with brand voice.
+- **Slug**: Derived from the heading. Lowercase, words separated by `-`, strip punctuation/stopwords where appropriate (e.g. `ai-engine-helping-brands`). 3–7 words is a good target.
+- **Content (HTML)**: Follow the patterns used by existing posts:
+  - Opening paragraph (`<p>`) that hooks the reader.
+  - `<h2>` section headings (not `<h1>` — the heading field supplies the H1).
+  - Short paragraphs, `<ul><li>` bullet lists for enumerations, `<blockquote><p>` for pull quotes with attributions in `<strong>`.
+  - Use semantic HTML — no inline styles or class attributes.
+  - Target 500–900 words unless the user specifies length.
+- Respect the brand guidelines' tone, terminology, and any banned phrasing.
+
+### 4. Upload the main image
+
+**First, look at the image(s).** Before uploading anything, use the Read tool on each image file the user provided. Claude can view JPEG/PNG/WebP directly — this is essential for writing accurate alt text, choosing a featured image, and making sure the image actually matches the post topic.
+
+**Featured image selection heuristics** (when the user provides several and doesn't specify which is the hero):
+
+1. Prefer landscape orientation — the blog header renders wide.
+2. Prefer images with a clear subject and strong composition.
+3. Prefer images that visually represent the post's main idea, not a minor detail.
+4. Tell the user which one you picked and why in your final report.
+5. If you can't analyze for some reason, use the first image.
+
+**Option A — user attached one or more new images:**
+
+1. Call `mcp__Agility-CMS__initialize_media_upload` for the chosen hero image with `instanceGuid`, a descriptive `fileName` (e.g. `predict-iq-hero.jpg` — don't carry through UUID-style filenames), and `folderPath: "mcp-uploads"` (or `"blog-images"` if the user prefers). If the user supplied multiple images, initialize all uploads in parallel (single tool-call batch).
+2. Each response includes an `uploadUrl` (expires in 5 minutes). Upload the file via curl — also in parallel if there are multiple:
+   ```bash
+   curl -s -X POST "<uploadUrl>" -F "file=@/absolute/path/to/image.jpg"
+   ```
+3. The curl response body contains the final CDN asset URL. Use that URL in the `Image` field when saving.
+
+**Option B — reusing an existing image from the media library:**
+
+Skip the upload step and set `Image` to `{ "url": "<existing-cdn-url>", "label": "<alt text>" }`.
+
+Either way, the `Image` field on the content item takes the shape:
+
+```json
+{
+  "url": "https://cdn.agilitycms.com/.../hero.jpg",
+  "label": "Short, descriptive alt text"
+}
+```
+
+**Do NOT duplicate the hero image inside the `Content` HTML body** — the post detail template renders it above the body automatically via the `PostImage` component. If the user provides other supporting images for the body, those can go in the HTML.
+
+### 5. Save the English post
+
+Call `mcp__Agility-CMS__save_content_items` with:
+
+- `instanceGuid`: `13f09fe2-u` (or user-specified)
+- `locale`: `en-us`
+- `items`: one item with `contentID: -1`, `referenceName: "Posts"`, and all fields from the "Content Model" table populated.
+
+Capture the returned `contentID` — you'll reuse it for the French translation.
+
+**Example payload (English):**
+
+```json
+{
+  "instanceGuid": "13f09fe2-u",
+  "locale": "en-us",
+  "items": [{
+    "contentID": -1,
+    "referenceName": "Posts",
+    "fields": {
+      "Heading": "…",
+      "Slug": "ai-engine-helping-brands",
+      "PostDate": "2026-04-21T00:00:00",
+      "Category": "categories",
+      "CategoryID": "6",
+      "CategoryName": "Industry Event",
+      "Tags": "tags",
+      "TagIDs": "9,8",
+      "TagNames": "Technology,A.I.",
+      "Author": "authors",
+      "AuthorID": "4",
+      "AuthorName": "Joel Varty",
+      "Content": "<p>…</p><h2>…</h2>…",
+      "Image": {
+        "url": "https://cdn.agilitycms.com/.../hero.jpg",
+        "label": "Descriptive alt text"
+      }
+    }
+  }]
+}
+```
+
+### 6. Translate to French
+
+Translate the post to Canadian French (`fr`). Requirements:
+
+- **Heading**: Translated naturally — do not translate brand / product names.
+- **Slug**: Keep IDENTICAL to the English slug (slugs are shared across locales).
+- **PostDate**: Same value as English.
+- **Category / Tags / Author**: Same `*ID` values as English (linked content is language-neutral). `CategoryName`, `TagNames`, `AuthorName` companion fields can stay as the English names OR be set to localized names if the user has localized them — default to keeping the English names since companions are mostly display helpers and translating them risks breaking filters.
+- **Content**: Translate naturally. Preserve HTML structure exactly (same `<h2>`, `<p>`, `<ul>`, `<blockquote>` tree). Preserve brand names, product names, and proper nouns untranslated. Adjust idioms; don't machine-translate word-for-word.
+- **Image**: Same `url` as English. Translate the `label` (alt text) to French.
+
+### 7. Save the French translation
+
+Call `mcp__Agility-CMS__save_content_items` AGAIN, but this time with:
+
+- `locale`: `fr`
+- The SAME `contentID` returned from step 5 (NOT `-1` — this creates/updates the French version of the same content item).
+- All fields translated per step 6.
+
+### 8. Report back
+
+Always end the response with the following block, filled in:
+
+- **Content ID**: `{contentID}`
+- **Edit in Agility (en-us)**: `https://app.agilitycms.com/instance/13f09fe2-u/en-us/content/list-9/listitem-{contentID}`
+- **Edit in Agility (fr)**: `https://app.agilitycms.com/instance/13f09fe2-u/fr/content/list-9/listitem-{contentID}`
+- **Preview (en-us)**: `https://demo.agilitycms.com/blog?ContentID={contentID}&lang=en-us&agilitypreviewkey=YSJChtivLrrzEdoJ6cric9bo7m%2fRLxAKsdDpcaVipHvA5kGPa1cTVkDVjWNeHlIGLfFTEW8Up6Gu4TOiYyBL3A%3d%3d&agilityts=20260421024609`
+- **Preview (fr)**: `https://demo.agilitycms.com/blog?ContentID={contentID}&lang=fr&agilitypreviewkey=YSJChtivLrrzEdoJ6cric9bo7m%2fRLxAKsdDpcaVipHvA5kGPa1cTVkDVjWNeHlIGLfFTEW8Up6Gu4TOiYyBL3A%3d%3d&agilityts=20260421024609`
+
+Notes on the URLs:
+- The edit URL's `list-9` segment is the **container ID** for `Posts` in this instance — don't change it.
+- The `agilitypreviewkey` is instance-scoped and stable. Keep it URL-encoded exactly as shown (the `%2f` and `%3d%3d` are intentional).
+- If the user wants fresh preview links, you can regenerate the `agilityts` value as the current UTC timestamp in `yyyyMMddHHmmss` format — but the existing value works indefinitely.
+- If the user targets a different `instanceGuid`, substitute it in the edit URL and warn that the preview key above only works for `13f09fe2-u`.
+
+Also mention that both locales were saved as **Staging** (default state). Posts still need to be reviewed and published in the CMS UI — do not attempt to set `state: 2` (Published) automatically unless the user explicitly asks.
+
+## Linked Content Reference
+
+For this instance, the currently known linked content (verify if stale):
+
+**Categories** (`Categories` container):
+- `7` — General Interest
+- `5` — News
+- `6` — Industry Event
+- `61` — Knowledge
+
+**Authors** (`Authors` container):
+- `4` — Joel Varty (default)
+- `58` — Vincent Dries
+- `59` — Emily Selman
+- `60` — Leo Krasner
+- `110` — Michael Foster
+
+**Tags** (`Tags` container):
+- `8` — A.I.
+- `9` — Technology
+- `10` — Commerce
+- `11` — Trends
+
+Always re-fetch these if unsure — new entries may have been added.
+
+## Content Formatting Rules
+
+HTML emitted into the `Content` field should match the style of existing posts:
+
+- Start with a hook paragraph, no heading at the top (the `Heading` field IS the H1).
+- Use `<h2>` for major sections. `<h3>` only if you need a sub-section.
+- Short paragraphs (2–4 sentences).
+- Use `<strong>` for emphasis on people/company names the first time they appear.
+- Use `<em>` for product names on first mention.
+- Pull quotes: `<blockquote><p>“…,” said <strong>Name</strong>, Title at Company.</p></blockquote>`.
+- Bullet lists: `<ul><li><strong>Label:</strong> Description</li>…</ul>`.
+- Do NOT inline `style="…"` or `class="…"` attributes — the site provides styling via Tailwind `prose`.
+- Do NOT wrap the whole thing in `<html>`, `<body>`, or `<article>`.
+
+## Creating New Categories, Tags, or Authors (Only If The User Explicitly Asks)
+
+**NEVER proactively create linked content.** If nothing fits, ask the user which existing item to use or whether they want to add a new one. Only run these calls when the user explicitly approves.
+
+**New Category** (save in both en-us and fr so the category works across locales):
+
+```
+mcp__Agility-CMS__save_content_items({
+  instanceGuid: "13f09fe2-u",
+  locale: "en-us",
+  items: [{
+    contentID: -1,
+    referenceName: "Categories",
+    fields: { Name: "Category Name" }
+  }]
+})
+```
+
+Capture the returned `contentID`, then save the French version at the SAME `contentID` with `locale: "fr"`.
+
+**New Tag**:
+
+```
+mcp__Agility-CMS__save_content_items({
+  instanceGuid: "13f09fe2-u",
+  locale: "en-us",
+  items: [{
+    contentID: -1,
+    referenceName: "Tags",
+    fields: { Name: "Tag Name" }
+  }]
+})
+```
+
+**New Author**: don't create authors programmatically without the user explicitly providing a name AND a headshot image — the site relies on the headshot for the byline layout. If requested, follow the same pattern but populate `Name` and `HeadShot` (ImageAttachment, same upload flow as the post hero image).
+
+## Example Session
+
+**User:** "Write a blog post about how headless CMS improves developer experience. Use the brand guidelines I attached. Here's a hero image." *[attaches `developer-at-desk.jpg`]*
+
+**Claude:**
+
+1. Reads `developer-at-desk.jpg` to confirm it's a landscape shot of a developer at a monitor — good hero material.
+2. In parallel: fetches Categories, Tags, Authors from the CMS.
+3. Picks Category `61` (Knowledge), Tags `9` (Technology) and `8` (A.I.), Author `4` (Joel Varty — default).
+4. Drafts the English post following the brand guidelines doc attached to the project:
+   - Heading: *"Why Headless CMS Changes the Developer Experience"*
+   - Slug: `headless-cms-developer-experience`
+   - PostDate: `2026-04-21T00:00:00`
+   - Content: HTML with a hook paragraph, three `<h2>` sections, a pull quote, and a bullet list.
+5. Initializes a media upload, curls the image up, captures the CDN URL.
+6. Saves the English post with `contentID: -1`, gets back e.g. `contentID: 312`.
+7. Translates Heading, Content (preserving HTML structure), and `Image.label` to French. Keeps slug, PostDate, and all `*ID` fields identical.
+8. Saves the French version at `contentID: 312`, `locale: "fr"`.
+9. Reports back with both Edit URLs, both Preview URLs, notes the post is in Staging, and mentions the hero image was selected because it's landscape with a clear subject.
+
+## Guardrails
+
+- **Never invent categories, tags, or authors.** Always pick from existing items.
+- **Never set `SocialPublishedDate`** — it's auto-managed.
+- **Never publish automatically.** Save as Staging and let the human editor review.
+- **Never translate proper nouns, product names, or brand-specific terms.**
+- **Never reuse an existing slug.** If the generated slug collides with an existing post, append a disambiguator (e.g. `-2026`).
+- **If image upload fails**, fall back to reusing an existing image URL and warn the user, rather than saving without an image.
+- **Confirm before saving** if anything is ambiguous (author choice, category fit, image selection).

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review-pr
 description: Review code changes in a pull request. Use when the user asks to review a PR, check PR changes, look at a pull request, or mentions reviewing code for merge.
 ---
 

--- a/docs/image-recos.md
+++ b/docs/image-recos.md
@@ -1,0 +1,532 @@
+# Image Best Practices for Agility CMS
+
+This guide covers recommendations for uploading and managing images in Agility CMS for optimal performance and quality. It is split into two parts:
+
+- **[For Content Editors](#for-content-editors)** — what formats, sizes, and dimensions to upload
+- **[For Developers](#for-developers)** — how to render images efficiently in code
+
+Code examples use Next.js, but the same principles apply to other frameworks. The `AgilityPic` component is also available in the [Blazor starter](https://github.com/agility/agilitycms-dotnet-starter/blob/main/Agility.NET.Blazor.Starter/Components/Shared/AgilityPic.razor) with similar functionality.
+
+## TL;DR
+
+| Rule                | Recommendation                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------ |
+| **Format**          | JPG for photos, PNG for screenshots/transparency                                           |
+| **Never upload**    | WebP or AVIF                                                                               |
+| **What matters**    | Pixel dimensions and compression, not DPI                                                  |
+| **Dimensions**      | 2x the display container size                                                              |
+| **Component**       | Use `AgilityPic` (renders `<picture>` with sources, routes transforms through Agility CDN) |
+| **High-DPI**        | Use `min-resolution: 2dppx` media queries in `sources`                                     |
+| **Mobile fallback** | Set `fallbackWidth` prop                                                                   |
+
+---
+
+## For Content Editors
+
+This section covers what you need to know when uploading images to Agility CMS. No coding knowledge required.
+
+## Source Image Requirements
+
+### Start with High-Quality Source Images
+
+Your website's image optimization pipeline relies on having high-quality source images to work with. When you upload a good source image, the system automatically resizes and converts it for each visitor's device and browser — you just need to provide the best starting point.
+
+### Recommended File Formats
+
+| Format       | Use For                               | Upload?                                                         |
+| ------------ | ------------------------------------- | --------------------------------------------------------------- |
+| **JPG/JPEG** | Photos                                | ✅ Yes                                                          |
+| **PNG**      | Screenshots, images with transparency | ✅ Yes                                                          |
+| **WebP**     | N/A                                   | ⛔ No                                                           |
+| **AVIF**     | N/A                                   | ⛔ No                                                           |
+| **SVG**      | Icons, logos, simple graphics         | ✅ Yes (passed through as-is, no resizing or format conversion) |
+
+**Simple rule:**
+
+- **Photos** → JPG
+- **Screenshots or transparency** → PNG
+
+### Do NOT Upload WebP or AVIF Files
+
+**This is critical**: Do not upload WebP or AVIF files to Agility CMS, especially if you are using a Next.js website - but it's true of any framework.
+
+**Why?** When you upload a WebP or AVIF file and it gets processed downstream (by the Agility CDN or Next.js Image optimization), the image undergoes double compression. These formats are already lossy-compressed, and re-compressing them causes:
+
+- Visible quality degradation and artifacts
+- Larger file sizes than expected (compression algorithms struggle with pre-compressed data)
+- Unpredictable visual results
+
+**The correct approach**: Upload high-quality JPG or PNG source files and let the CDN handle format conversion automatically using the `format=auto` parameter. This ensures browsers receive the optimal format (WebP, AVIF, or original) without double compression.
+
+**Exception**: You may upload WebP/AVIF only if you are certain the image will not be processed or transformed downstream. This is rare in most Agility CMS implementations.
+
+## Image Dimensions
+
+### Does the image need to match the container exactly?
+
+No. You should upload images larger than the container size. The optimization pipeline will resize images as needed.
+
+**Best practice**: Upload images at **2x the resolution** of the image container to support 4K and Retina displays. These high-density displays have more pixels per inch, and using 2x resolution ensures images appear crisp rather than blurry.
+
+For example:
+
+- Hero banner displays at 1920px wide → upload at 3840px wide
+- Thumbnail displays at 400px wide → upload at 800px wide
+- Content image displays at 600px wide → upload at 1200px wide
+
+### Recommended Source Dimensions by Use Case
+
+| Image Type        | Display Size | Upload At (2x) |
+| ----------------- | ------------ | -------------- |
+| Hero/Banner       | 1920px       | 3840px         |
+| Content images    | 1200px       | 2400px         |
+| Thumbnails        | 400px        | 800px          |
+| Icons             | 128px or SVG | 256px or SVG   |
+| Background images | 1920px       | 3840px         |
+
+If you want your images to be used in multiple places (eg: if the image is shared across multiple components or items), then it should be uploaded with maximum size needed anywhere it's used.
+
+### A Note on DPI
+
+**DPI does not matter for web images.** Browsers render images based on pixel dimensions, not DPI metadata. A 1000x1000px image at 72 DPI and the same image at 300 DPI will look identical on screen and produce the same file size — the DPI number in the metadata is ignored.
+
+What actually determines image quality and file size on the web:
+
+- **Pixel dimensions** (width x height) — this is what you should focus on
+- **Compression settings** (JPEG quality level, etc.)
+- **Format choice** (JPG, PNG, etc.)
+
+The old advice to "use 72 DPI" comes from early Mac displays that were roughly 72 pixels per inch. Modern screens range from ~96 PPI to 3x or 4x density, and none of them read the DPI metadata.
+
+**Watch out for inflated exports:** The practical danger of high DPI settings is that design tools like Photoshop may scale pixel dimensions up to match. For example, exporting a 1920px design at 300 DPI instead of 72 DPI can produce an 8000px-wide file — far larger than needed and wasteful to upload. When exporting, always verify the **pixel dimensions** match what you intend (2x display size), regardless of what the DPI field says.
+
+## File Size Guidelines
+
+While the optimization pipeline compresses images automatically, starting with reasonably sized source files speeds up uploads and processing.
+
+These targets assume you are uploading at 2x dimensions as recommended above. A high-quality 3840px-wide JPG will naturally be larger than a 1920px version — that is expected.
+
+| Image Type        | Ideal Source Size | Maximum Source Size |
+| ----------------- | ----------------- | ------------------- |
+| Hero/Banner       | 400 KB - 1 MB     | 2 MB                |
+| Content images    | 200-500 KB        | 1 MB                |
+| Icons             | < 20 KB           | 50 KB               |
+| Background images | 400 KB - 1 MB     | 2 MB                |
+
+**How large is too large?**
+
+Files over 5 MB should be avoided. They slow down uploads, increase processing time, and rarely provide quality benefits over smaller optimized files.
+
+---
+
+## For Developers
+
+This section covers how to render Agility CMS images in your code for optimal performance. Examples use Next.js, but the concepts apply to any framework with an AgilityPic component.
+
+## Ensuring format=auto on All Image Sources
+
+**All images served from Agility CMS should include the `format=auto` parameter.** This tells the CDN to automatically serve the optimal format based on browser support (AVIF/WebP where supported, or the original format as fallback).
+
+### Why This Matters
+
+Without `format=auto`, images are served in their original format regardless of browser capabilities. This means:
+
+- Users receive larger JPG/PNG files even when their browser supports WebP
+- You miss out on significant file size savings of 30-60%
+- Page performance suffers unnecessarily
+
+### How format=auto Works
+
+When you append `?format=auto` to an Agility CDN image URL:
+
+```
+# Original URL
+https://cdn.agilitycms.com/your-instance/media/images/hero.jpg
+
+# With format=auto
+https://cdn.agilitycms.com/your-instance/media/images/hero.jpg?format=auto
+```
+
+The CDN inspects the browser's `Accept` header and returns:
+
+- **WebP** if the browser supports it
+- **AVIF** if the browser supports it (and it's enabled)
+- **Original format** as fallback
+
+### How format=auto Gets Applied in Practice
+
+`format=auto` should be applied automatically at the component level — editors should never need to add it manually.
+
+- **Image fields** — Use `AgilityPic` (or `AgilityImage`). Both append `format=auto` to all generated URLs automatically. See [Using the AgilityPic Component](#using-the-agilitypic-component) for details.
+- **Rich content fields** (HTML, Markdown, Block Editor) — Post-process the rendered output to add `format=auto` to embedded `<img>` tags. See [Processing Images in Rich Content](#processing-images-in-rich-content-html-markdown-block-editor) below.
+
+### Audit Existing Content
+
+Review your codebase to ensure:
+
+1. **All image components** use AgilityPic or apply `format=auto`
+2. **Rich text/HTML fields** are pre-processed before rendering
+3. **Custom image implementations** include the format parameter
+4. **No hardcoded image URLs** bypass the optimization pipeline
+
+## Processing Images in Rich Content (HTML, Markdown, Block Editor)
+
+Images rendered through `AgilityPic` get `format=auto` and lazy loading automatically. However, images embedded inside rich content fields — HTML (Rich Text Editor), Markdown, or Block Editor content — are **not processed by default**. These images are rendered as raw `<img>` tags, which means they bypass the optimization pipeline entirely.
+
+This is a common gap. If your site has rich content fields with embedded images, you should post-process the rendered output before displaying it.
+
+### What to Post-Process
+
+For every `<img>` tag in rich content output:
+
+1. **Add `format=auto`** to image URLs (if not already present)
+2. **Add `w` (width)** to cap the image at a sensible maximum — without this, a 3840px source image gets served at full size even if the content area is only 800px wide. Set this based on your content layout (e.g., `1200` for a typical content column, `1920` for full-width)
+3. **Add `loading="lazy"`** to images that don't have a `loading` attribute set
+
+### Example: HTML / Rich Text Fields
+
+Use a library like [cheerio](https://cheerio.js.org/) to parse and transform the HTML before rendering. The `maxWidth` parameter should match the maximum width images can appear at in your content area:
+
+```typescript
+import * as cheerio from 'cheerio'
+
+export const renderHTMLCustom = (html: string | null | undefined, maxWidth: number = 1200) => {
+  if (!html) return { __html: '' }
+
+  let str = html
+
+  try {
+    const $ = cheerio.load(str)
+    $('img').each((_, element) => {
+      const src = $(element).attr('src')
+
+      if (src) {
+        try {
+          const parsed = new URL(src)
+
+          // Add format=auto if not already present
+          if (!parsed.searchParams.has('format')) {
+            parsed.searchParams.set('format', 'auto')
+          }
+
+          // Cap width to avoid serving oversized images
+          if (!parsed.searchParams.has('w')) {
+            parsed.searchParams.set('w', String(maxWidth))
+          }
+
+          $(element).attr('src', parsed.toString())
+        } catch {
+          // Not a valid absolute URL, skip
+        }
+      }
+
+      // Enable lazy loading if not explicitly set
+      if (!$(element).attr('loading')) {
+        $(element).attr('loading', 'lazy')
+      }
+    })
+
+    str = $.html()
+  } catch (error) {
+    console.error('Error parsing HTML in renderHTMLCustom', error)
+  }
+
+  return { __html: str }
+}
+```
+
+Then use it in your component, setting `maxWidth` to match your layout:
+
+```tsx
+// Content area is ~800px wide
+<div dangerouslySetInnerHTML={renderHTMLCustom(fields.content, 800)} />
+
+// Full-width layout
+<div dangerouslySetInnerHTML={renderHTMLCustom(fields.content, 1920)} />
+```
+
+### Advanced: Responsive Images in Rich Content
+
+The example above serves a single image size to all devices. For better page speed scores — especially on mobile — you can replace each `<img>` with a `<picture>` element that serves a smaller image on mobile and a larger one on desktop, just like `AgilityPic` does for image fields.
+
+```typescript
+// Replace <img> with <picture> for responsive rich content images
+$('img').each((_, element) => {
+  const src = $(element).attr('src')
+  if (!src) return
+
+  try {
+    const parsed = new URL(src)
+    parsed.searchParams.set('format', 'auto')
+
+    // Build sources for different breakpoints
+    const desktop = new URL(parsed)
+    desktop.searchParams.set('w', String(maxWidth))
+
+    const mobile = new URL(parsed)
+    mobile.searchParams.set('w', String(Math.round(maxWidth / 2)))
+
+    const picture = `<picture>
+      <source media="(min-width: 640px)" srcset="${desktop.toString()}" />
+      <img src="${mobile.toString()}" alt="${$(element).attr('alt') || ''}" loading="lazy" class="${$(element).attr('class') || ''}" />
+    </picture>`
+
+    $(element).replaceWith(picture)
+  } catch {
+    // Not a valid absolute URL, skip
+  }
+})
+```
+
+This is more work to implement, but it means mobile users download a smaller image while desktop users still get the full-width version.
+
+### Markdown and Block Editor Content
+
+The same principle applies — after converting Markdown or Block Editor JSON to HTML, run the output through a similar post-processor before rendering. The implementation will vary by framework and Markdown library, but the logic is the same: find `<img>` tags and add `format=auto` and a `w` parameter to cap the width.
+
+### Why This Matters
+
+Without post-processing, images inside rich content fields are served in their original format at their full source dimensions. A 3840px-wide hero image pasted into a blog post gets delivered at 3840px even though the content column is 800px wide. On a content-heavy site, this can mean dozens of oversized, unoptimized images per page — negating the performance gains you get from using `AgilityPic` elsewhere.
+
+## Using the AgilityPic Component
+
+The `AgilityPic` component renders a native HTML `<picture>` element with `<source>` tags and a fallback `<img>`. It does **not** use `next/image` — instead, it builds image URLs directly using the Agility Image API, appending `?format=auto&w=...` to each source.
+
+> **Note:** If you need `next/image` features (e.g., blur placeholder, priority preload) for Agility CMS images, use `AgilityImage` instead — it wraps `next/image` with a custom loader that routes transforms through the Agility CDN. For non-Agility images, use `next/image` directly.
+
+**How it handles `format=auto`:** AgilityPic automatically appends `format=auto` to all image URLs it generates — both for each `<source>` and the fallback `<img>`. You do not need to add query parameters manually. Every image rendered through AgilityPic gets automatic format negotiation (WebP, AVIF, or original) with no extra work.
+
+**Why use AgilityPic:**
+
+- **Native `<picture>` element** — no client component requirement, no JavaScript overhead
+- **Agility CDN handles transformations** (not your web server's CPU)
+- **Automatic `format=auto`** on all generated URLs
+- **Won't upscale** — if you request a width larger than the source image, it caps at the source width
+- **Responsive source selection** via the `sources` array with media queries
+- **High-DPI support** via media queries with `min-resolution`
+
+### Props Overview
+
+| Prop            | Description                                                                          |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `image`         | Agility CMS image object (from ImageAttachment field)                                |
+| `fallbackWidth` | Width for mobile/default fallback image                                              |
+| `sources`       | Array of responsive breakpoints with media queries                                   |
+| `priority`      | If `true`, sets `loading="eager"` on the fallback `<img>`. Defaults to lazy loading. |
+| `className`     | CSS classes for the fallback `<img>` (inherited by sources)                          |
+| `alt`           | Override alt text (defaults to `image.label`)                                        |
+
+### Basic Usage
+
+```tsx
+import { AgilityPic } from '@agility/nextjs'
+;<AgilityPic
+  image={fields.image}
+  className="h-full w-full object-cover"
+  fallbackWidth={640}
+/>
+```
+
+### Responsive Images with High-DPI Support
+
+Use the `sources` array to serve different image sizes based on screen width and pixel density. This ensures:
+
+- Mobile devices get smaller images (faster loading)
+- Desktop gets appropriately sized images
+- High-DPI displays (Retina, 4K) get 2x resolution images
+
+**Example: Hero/Banner Image**
+
+```tsx
+<AgilityPic
+  image={fields.heroImage}
+  className="h-full w-full object-cover"
+  fallbackWidth={640}
+  sources={[
+    // Desktop - high DPI first (more specific)
+    { media: '(min-width: 1280px) and (min-resolution: 2dppx)', width: 2400 },
+    { media: '(min-width: 1280px)', width: 1200 },
+    // Tablet - high DPI
+    { media: '(min-width: 640px) and (min-resolution: 2dppx)', width: 1600 },
+    { media: '(min-width: 640px)', width: 800 },
+    // Mobile - high DPI
+    { media: '(max-width: 639px) and (min-resolution: 2dppx)', width: 1280 },
+    { media: '(max-width: 639px)', width: 640 },
+  ]}
+/>
+```
+
+**Example: Content Image**
+
+```tsx
+<AgilityPic
+  image={fields.image}
+  className="h-full w-full object-cover"
+  fallbackWidth={400}
+  sources={[
+    // Desktop - high DPI
+    { media: '(min-width: 1280px) and (min-resolution: 2dppx)', width: 1600 },
+    { media: '(min-width: 1280px)', width: 800 },
+    // Tablet - high DPI
+    { media: '(min-width: 640px) and (min-resolution: 2dppx)', width: 1200 },
+    { media: '(min-width: 640px)', width: 600 },
+  ]}
+/>
+```
+
+**Example: Thumbnail**
+
+```tsx
+<AgilityPic
+  image={fields.thumbnail}
+  className="h-full w-full object-cover"
+  fallbackWidth={200}
+  sources={[
+    // Tablet+ - high DPI
+    { media: '(min-width: 640px) and (min-resolution: 2dppx)', width: 600 },
+    { media: '(min-width: 640px)', width: 300 },
+  ]}
+/>
+```
+
+### Media Query Order
+
+**Important**: Always place high-DPI queries (more specific) before standard queries. The browser uses the first matching media query, so more specific rules must come first.
+
+```tsx
+// ✅ Correct - high DPI first
+sources={[
+  { media: "(min-width: 1280px) and (min-resolution: 2dppx)", width: 2400 },
+  { media: "(min-width: 1280px)", width: 1200 },
+]}
+
+// ❌ Wrong - standard query would always match first
+sources={[
+  { media: "(min-width: 1280px)", width: 1200 },
+  { media: "(min-width: 1280px) and (min-resolution: 2dppx)", width: 2400 },
+]}
+```
+
+### Common Breakpoints
+
+These breakpoints align with Tailwind CSS defaults:
+
+| Breakpoint         | Screen Width | Typical Use         |
+| ------------------ | ------------ | ------------------- |
+| Mobile             | < 640px      | `max-width: 639px`  |
+| Tablet (sm)        | ≥ 640px      | `min-width: 640px`  |
+| Desktop (lg)       | ≥ 1024px     | `min-width: 1024px` |
+| Large Desktop (xl) | ≥ 1280px     | `min-width: 1280px` |
+
+### Lazy Loading
+
+AgilityPic defaults to `loading="lazy"` on the fallback `<img>`, so images below the fold are lazy-loaded automatically with no extra configuration.
+
+For above-the-fold images (like hero banners), set `priority` to load them eagerly:
+
+```tsx
+<AgilityPic image={fields.heroImage} fallbackWidth={640} priority />
+```
+
+## AgilityPic vs AgilityImage vs next/image
+
+| Component               | What it renders                   | Transforms via  | Use when                                                                  |
+| ----------------------- | --------------------------------- | --------------- | ------------------------------------------------------------------------- |
+| **AgilityPic**          | `<picture>` with `<source>` tags  | Agility CDN     | You want full control over responsive sources and media queries           |
+| **AgilityImage**        | `next/image` with a custom loader | Agility CDN     | You need `next/image` features (blur placeholder, priority preload, etc.) |
+| **next/image** (direct) | `next/image` with default loader  | Your web server | Non-Agility images only                                                   |
+
+**Prefer `AgilityPic`** for Agility CMS images. It gives you explicit control over what sizes are served at which breakpoints, uses the native `<picture>` element, and doesn't require a client component.
+
+**Use `AgilityImage`** if you need specific `next/image` features. It wraps `next/image` with a loader that routes through the Agility CDN, so transforms still happen on the CDN rather than your server.
+
+**Avoid raw `next/image`** for Agility images — transforms happen on your web server, there's no automatic cache invalidation, and you have to handle `format=auto` manually.
+
+## CMS Field Validation
+
+Agility CMS allows you to enforce image guidelines through field validation on your Content Models and Components.
+
+### Available Validations
+
+- **File Size**: Set minimum/maximum file size limits
+- **Image Width**: Set minimum/maximum width requirements
+- **Image Height**: Set minimum/maximum height requirements
+- **Valid File Types**: Restrict to specific formats (e.g., `*.jpg,*.jpeg,*.png`)
+- **Alt Text Required**: Enforce accessibility compliance
+
+### Setting Up Validation
+
+1. Navigate to **Models** in Agility CMS
+2. Select your Content Model or Component
+3. Add or edit an Image Field
+4. Click **Field Properties**
+5. Configure your validation rules
+6. Add a custom validation message to guide editors
+
+### Example Validation Settings
+
+For a Hero Banner field:
+
+- File Size: Max 2 MB
+- Image Width: Min 1920px
+- Valid File Types: `*.jpg,*.jpeg,*.png` (do NOT include WebP or AVIF)
+- Require Alt Text: Yes
+- Validation Message: "Please upload a high-resolution image (minimum 1920px wide, max 2MB) in JPG or PNG format. Do not upload WebP or AVIF files."
+
+## Quick Reference Checklist
+
+Before uploading an image, verify:
+
+- [ ] Format is correct: JPG for photos, PNG for screenshots or transparency
+- [ ] NOT WebP or AVIF
+- [ ] Pixel dimensions are correct (not inflated by a high DPI export setting)
+- [ ] Dimensions are 2x the display container size (for 4K/Retina support)
+- [ ] File size is under the recommended maximum for its type
+- [ ] Alt text is prepared for accessibility
+- [ ] Image is not stretched or distorted
+
+For your codebase, verify:
+
+- [ ] All image components use `AgilityPic` (not raw `<img>` tags or Next.js Image)
+- [ ] `AgilityPic` includes `sources` array for responsive sizing
+- [ ] High-DPI media queries are listed before standard queries
+- [ ] `fallbackWidth` is set for mobile default
+- [ ] Above-the-fold images use `priority` prop (AgilityPic lazy-loads by default)
+- [ ] Rich text, Markdown, and Block Editor content is post-processed for `format=auto` and `loading="lazy"`
+
+## Troubleshooting
+
+### Images appear blurry
+
+- Source image dimensions are too small
+- Upload a larger source image (2x display size recommended)
+
+### Images load slowly
+
+- Source file size is too large
+- Optimize the source image before uploading (use tools like ImageOptim, TinyPNG)
+- Verify `format=auto` is being applied to URLs
+
+### Images have visible artifacts or look over-compressed
+
+- Source file may be WebP or AVIF (double compression)
+- Replace with original JPG or PNG source file
+- Check if multiple optimization passes are occurring
+
+### Images not updating after changes in CMS
+
+- If using Next.js Image component directly, images may be cached
+- Use AgilityPic component for automatic cache invalidation
+- Clear your CDN cache if using a custom CDN layer
+
+### format=auto not working
+
+- Verify the URL includes the parameter: `?format=auto` or `&format=auto`
+- Check browser DevTools Network tab to confirm the response content-type
+- Ensure the image is served from the Agility CDN (cdn.agilitycms.com)
+
+## Additional Resources
+
+- [Using the AgilityPic Component for Responsive Images](/docs/nextjs/using-the-agilitypic-component-for-responsive-images)
+- [Field Types for Content and Modules](/docs/developers/fields)
+- [Next.js Image Optimization Documentation](https://nextjs.org/docs/app/building-your-application/optimizing/images)

--- a/src/app/api/preview/exit/route.ts
+++ b/src/app/api/preview/exit/route.ts
@@ -1,4 +1,5 @@
 "use server";
+import { localizeUrl } from "@/lib/i18n/localizeUrl";
 import { getDynamicPageURL } from '@agility/nextjs/node';
 import { draftMode } from 'next/headers'
 import { NextRequest, NextResponse } from "next/server";
@@ -9,16 +10,20 @@ export async function GET(request: NextRequest) {
 
 	const slug = searchParams.get('slug');
 	const ContentID = searchParams.get('ContentID');
+	const locale = searchParams.get('locale') || searchParams.get('lang');
 
 	//disable draft/preview mode
 	(await draftMode()).disable()
 
-	let url = new URL(slug || '', request.nextUrl.origin).toString();
+	let path = slug || '/';
+	if (locale) path = localizeUrl(path, locale);
+	let url = new URL(path, request.nextUrl.origin).toString();
 
 	if (ContentID) {
 		const dynamicPath = await getDynamicPageURL({ contentID: Number(ContentID), preview: false, slug: slug || undefined });
 		if (dynamicPath) {
-			url = new URL(dynamicPath, request.nextUrl.origin).toString();
+			const localizedDynamic = locale ? localizeUrl(dynamicPath, locale) : dynamicPath;
+			url = new URL(localizedDynamic, request.nextUrl.origin).toString();
 		}
 	}
 

--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
 	if (ContentID) {
 		const dynamicPath = await getDynamicPageURL({ contentID: Number(ContentID), preview: true, slug: slug || undefined });
 		if (dynamicPath) {
-			previewUrl = dynamicPath;
+			previewUrl = locale ? localizeUrl(dynamicPath, locale) : dynamicPath;
 		}
 
 	}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -4,6 +4,7 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import agilitySDK from "@agility/content-fetch"
 import type { SitemapNode } from "@/lib/types/SitemapNode";
+import { publishPostToSocial } from "@/lib/social/publishPost";
 
 interface IRevalidateRequest {
 	state: string,
@@ -99,6 +100,19 @@ export async function POST(req: NextRequest) {
 				}
 			}
 		}
+		// --- Social media auto-publish for blog posts ---
+		if (
+			data.referenceName?.toLowerCase() === "posts" &&
+			data.contentID &&
+			data.languageCode
+		) {
+			// Fire-and-forget: don't block the webhook response
+			publishPostToSocial({
+				contentID: data.contentID,
+				languageCode: data.languageCode,
+			}).catch((err) => console.error("[social] Unexpected error:", err))
+		}
+
 	} else if (data.contentID === undefined && data.pageID === undefined) {
 		//if no content or page id is provided, it's for a URL redirection
 		//trigger the rebuild hook for netlify's rebuild...

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,7 +23,14 @@ type RequiredEnvVars = {
 }
 
 type OptionalEnvVars = {
-	// Add any optional environment variables here
+	// Social media auto-publishing (Hootsuite)
+	HOOTSUITE_ACCESS_TOKEN: string
+	HOOTSUITE_PROFILE_IDS: string
+	HOOTSUITE_API_URL: string
+	// Agility management API (for writing socialPublishedDate back to CMS)
+	AGILITY_API_MANAGEMENT_KEY: string
+	// Site URL for building post links
+	SITE_URL: string
 }
 
 type EnvVars = RequiredEnvVars & Partial<OptionalEnvVars>

--- a/src/lib/i18n/localizeUrl.ts
+++ b/src/lib/i18n/localizeUrl.ts
@@ -1,10 +1,11 @@
 import { type URLField } from "@agility/nextjs"
-import { type Locale, defaultLocale } from "./config"
+import { type Locale, defaultLocale, locales, getLocaleFromPathname, removeLocaleFromPathname } from "./config"
 
 /**
- * Localizes a URL based on the current locale
- * For default locale (en-us), returns the URL as is
- * For other locales, prefixes the URL with the locale
+ * Localizes a URL based on the current locale.
+ * For default locale (en-us), returns the URL without a locale prefix.
+ * For other locales, prefixes the URL with the locale.
+ * Idempotent: if the URL already starts with any known locale prefix, that prefix is stripped before the target locale is applied.
  */
 export function localizeUrl(url: string, locale: Locale): string {
   // Handle external URLs (don't localize)
@@ -18,9 +19,15 @@ export function localizeUrl(url: string, locale: Locale): string {
   }
 
   // Ensure URL starts with /
-  const normalizedUrl = url.startsWith('/') ? url : `/${url}`
+  let normalizedUrl = url.startsWith('/') ? url : `/${url}`
 
-  // For default locale, return URL as is
+  // Strip any existing locale prefix so we don't produce paths like /fr/fr/blog
+  const existingLocale = getLocaleFromPathname(normalizedUrl, locales)
+  if (existingLocale) {
+    normalizedUrl = removeLocaleFromPathname(normalizedUrl, existingLocale)
+  }
+
+  // For default locale, return URL without a prefix
   if (locale === defaultLocale) {
     return normalizedUrl
   }

--- a/src/lib/social/providers/hootsuite.ts
+++ b/src/lib/social/providers/hootsuite.ts
@@ -1,0 +1,105 @@
+import type { SocialMediaProvider, SocialPost, SocialPublishResult } from "../types"
+
+/**
+ * Hootsuite provider – schedules posts via the Hootsuite REST API v1.
+ *
+ * Required env vars:
+ *   HOOTSUITE_ACCESS_TOKEN   – OAuth 2 Bearer token
+ *   HOOTSUITE_PROFILE_IDS    – Comma-separated social profile IDs to post to
+ *
+ * Optional:
+ *   HOOTSUITE_API_URL         – Override the API base (defaults to https://platform.hootsuite.com)
+ */
+export class HootsuiteProvider implements SocialMediaProvider {
+	readonly name = "Hootsuite"
+
+	private get apiUrl(): string {
+		return process.env.HOOTSUITE_API_URL || "https://platform.hootsuite.com"
+	}
+
+	private get accessToken(): string | undefined {
+		return process.env.HOOTSUITE_ACCESS_TOKEN
+	}
+
+	private get profileIds(): string[] {
+		const raw = process.env.HOOTSUITE_PROFILE_IDS
+		if (!raw) return []
+		return raw.split(",").map((id) => id.trim()).filter(Boolean)
+	}
+
+	isConfigured(): boolean {
+		return Boolean(this.accessToken) && this.profileIds.length > 0
+	}
+
+	async publishPost(post: SocialPost): Promise<SocialPublishResult> {
+		if (!this.isConfigured()) {
+			return { success: false, provider: this.name, error: "Hootsuite is not configured" }
+		}
+
+		const text = this.formatPostText(post)
+
+		try {
+			const res = await fetch(`${this.apiUrl}/v1/messages`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${this.accessToken}`,
+				},
+				body: JSON.stringify({
+					text,
+					socialProfileIds: this.profileIds,
+					scheduledSendTime: new Date().toISOString(),
+				}),
+			})
+
+			if (!res.ok) {
+				const body = await res.text()
+				console.error(`[social] Hootsuite API error ${res.status}: ${body}`)
+				return { success: false, provider: this.name, error: `HTTP ${res.status}: ${body}` }
+			}
+
+			const data = (await res.json()) as { data?: { id?: string } }
+			return {
+				success: true,
+				provider: this.name,
+				externalId: data.data?.id,
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err)
+			console.error(`[social] Hootsuite publish failed:`, message)
+			return { success: false, provider: this.name, error: message }
+		}
+	}
+
+	/**
+	 * Format the social media post text.
+	 * Pattern:  Title
+	 *           Excerpt…
+	 *           #tag1 #tag2
+	 *           url
+	 */
+	private formatPostText(post: SocialPost): string {
+		const parts: string[] = [post.title]
+
+		if (post.excerpt) {
+			// Trim excerpt to stay well within platform character limits
+			const maxExcerpt = 200
+			const excerpt =
+				post.excerpt.length > maxExcerpt
+					? post.excerpt.substring(0, maxExcerpt).trimEnd() + "..."
+					: post.excerpt
+			parts.push(excerpt)
+		}
+
+		if (post.tags && post.tags.length > 0) {
+			const hashtags = post.tags
+				.map((t) => `#${t.replace(/\s+/g, "")}`)
+				.join(" ")
+			parts.push(hashtags)
+		}
+
+		parts.push(post.url)
+
+		return parts.join("\n\n")
+	}
+}

--- a/src/lib/social/publishPost.ts
+++ b/src/lib/social/publishPost.ts
@@ -1,0 +1,197 @@
+import agilitySDK from "@agility/content-fetch"
+import type { SocialMediaProvider, SocialPost, SocialPublishResult } from "./types"
+import { HootsuiteProvider } from "./providers/hootsuite"
+
+// ---------------------------------------------------------------------------
+// Provider registry – add new providers here
+// ---------------------------------------------------------------------------
+const providers: SocialMediaProvider[] = [new HootsuiteProvider()]
+
+function getActiveProviders(): SocialMediaProvider[] {
+	return providers.filter((p) => p.isConfigured())
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface PublishToSocialParams {
+	contentID: number
+	languageCode: string
+}
+
+/**
+ * Fetch a blog post from Agility CMS, check whether it has already been
+ * shared to social media, and if not publish it via every configured provider.
+ *
+ * After a successful publish, the `socialPublishedDate` field is written back
+ * to the CMS so the same post is never shared twice.
+ *
+ * @returns array of results from each provider, or `null` if the post was
+ *          skipped (already shared or not a blog post).
+ */
+export async function publishPostToSocial({
+	contentID,
+	languageCode,
+}: PublishToSocialParams): Promise<SocialPublishResult[] | null> {
+	const active = getActiveProviders()
+	if (active.length === 0) {
+		console.info("[social] No social media providers configured – skipping.")
+		return null
+	}
+
+	// Fetch the content item directly (no cache – we need current data)
+	const apiKey = process.env.AGILITY_API_FETCH_KEY
+	const guid = process.env.AGILITY_GUID
+	if (!apiKey || !guid) {
+		console.error("[social] Missing AGILITY_GUID or AGILITY_API_FETCH_KEY")
+		return null
+	}
+
+	const client = agilitySDK.getApi({ guid, apiKey })
+	client.config.fetchConfig = { cache: "no-store" }
+
+	let item: any
+	try {
+		item = await client.getContentItem({ contentID, languageCode, contentLinkDepth: 2 })
+	} catch (err) {
+		console.error(`[social] Could not fetch content item ${contentID}:`, err)
+		return null
+	}
+
+	if (!item?.fields) {
+		console.info(`[social] Content item ${contentID} has no fields – skipping.`)
+		return null
+	}
+
+	// ---- Dedup: already published to social? ----
+	if (item.fields.socialPublishedDate) {
+		console.info(
+			`[social] Post ${contentID} was already shared on ${item.fields.socialPublishedDate} – skipping.`
+		)
+		return null
+	}
+
+	// ---- Build the social post payload ----
+	const siteUrl =
+		process.env.SITE_URL ||
+		(process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "https://localhost:3000")
+
+	const postUrl = await resolvePostUrl(client, contentID, languageCode, siteUrl)
+	const excerpt = stripHtml(item.fields.content || "").substring(0, 250)
+
+	const tags: string[] = []
+	if (item.fields.tags) {
+		const tagItems = Array.isArray(item.fields.tags) ? item.fields.tags : [item.fields.tags]
+		for (const t of tagItems) {
+			if (t?.fields?.title) tags.push(t.fields.title)
+		}
+	}
+
+	const socialPost: SocialPost = {
+		title: item.fields.heading,
+		excerpt,
+		url: postUrl,
+		imageUrl: item.fields.image?.url || undefined,
+		tags,
+	}
+
+	console.info(`[social] Publishing post ${contentID} "${socialPost.title}" to ${active.map((p) => p.name).join(", ")}`)
+
+	// ---- Publish to all configured providers concurrently ----
+	const results = await Promise.all(active.map((p) => p.publishPost(socialPost)))
+
+	const anySuccess = results.some((r) => r.success)
+
+	// ---- Write-back: stamp socialPublishedDate if at least one provider succeeded ----
+	if (anySuccess) {
+		await writeSocialPublishedDate(contentID, languageCode)
+	}
+
+	for (const r of results) {
+		if (r.success) {
+			console.info(`[social] ${r.provider}: published (externalId=${r.externalId})`)
+		} else {
+			console.error(`[social] ${r.provider}: failed – ${r.error}`)
+		}
+	}
+
+	return results
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve the full public URL of a blog post via the sitemap. */
+async function resolvePostUrl(
+	client: any,
+	contentID: number,
+	languageCode: string,
+	siteUrl: string
+): Promise<string> {
+	try {
+		const sitemap = await client.getSitemapFlat({
+			channelName: process.env.AGILITY_SITEMAP || "website",
+			languageCode,
+		})
+		const node = Object.values(sitemap).find((s: any) => s.contentID === contentID) as any
+		if (node?.path) {
+			return `${siteUrl}${node.path}`
+		}
+	} catch {
+		// fall through to generic URL
+	}
+	return `${siteUrl}/blog`
+}
+
+/** Strip HTML tags from a string. */
+function stripHtml(html: string): string {
+	return html.replace(/<[^>]*>/g, "").trim()
+}
+
+/**
+ * Write the current timestamp into the `socialPublishedDate` field on the
+ * content item via the Agility Management REST API.
+ *
+ * Requires `AGILITY_API_MANAGEMENT_KEY` to be set.
+ *
+ * When this save is published in the CMS it will trigger the revalidate
+ * webhook again, but the dedup check (socialPublishedDate already set) will
+ * cause it to be skipped.
+ */
+async function writeSocialPublishedDate(contentID: number, languageCode: string): Promise<void> {
+	const mgmtKey = process.env.AGILITY_API_MANAGEMENT_KEY
+	const guid = process.env.AGILITY_GUID
+	if (!mgmtKey || !guid) {
+		console.warn("[social] Cannot write-back socialPublishedDate – AGILITY_API_MANAGEMENT_KEY not set.")
+		return
+	}
+
+	const url = `https://mgmt.aglty.io/${guid}/api/${languageCode}/item/${contentID}`
+
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				APIKey: mgmtKey,
+			},
+			body: JSON.stringify({
+				contentID,
+				fields: {
+					socialPublishedDate: new Date().toISOString(),
+				},
+			}),
+		})
+
+		if (!res.ok) {
+			const body = await res.text()
+			console.error(`[social] Management API write-back failed ${res.status}: ${body}`)
+		} else {
+			console.info(`[social] socialPublishedDate written for item ${contentID}`)
+		}
+	} catch (err) {
+		console.error("[social] Management API write-back error:", err)
+	}
+}

--- a/src/lib/social/types.ts
+++ b/src/lib/social/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Social media auto-publishing interfaces.
+ *
+ * To add a new provider, implement the `SocialMediaProvider` interface
+ * and register it in `src/lib/social/publishPost.ts`.
+ */
+
+/** The post payload sent to social media providers. */
+export interface SocialPost {
+	title: string
+	excerpt: string
+	url: string
+	imageUrl?: string
+	tags?: string[]
+}
+
+/** Result returned from a provider after attempting to publish. */
+export interface SocialPublishResult {
+	success: boolean
+	provider: string
+	/** ID of the post/message on the external platform. */
+	externalId?: string
+	error?: string
+}
+
+/** Every social media provider must implement this interface. */
+export interface SocialMediaProvider {
+	/** Human-readable provider name (e.g. "Hootsuite"). */
+	readonly name: string
+
+	/**
+	 * Returns true when the provider has been configured with the required
+	 * environment variables and is ready to accept publish calls.
+	 */
+	isConfigured(): boolean
+
+	/**
+	 * Publish / schedule a post on the external platform.
+	 */
+	publishPost(post: SocialPost): Promise<SocialPublishResult>
+}

--- a/src/lib/types/IPost.ts
+++ b/src/lib/types/IPost.ts
@@ -12,4 +12,6 @@ export interface IPost {
 	category: ContentItem<ICategory>
 	author: ContentItem<IAuthor>
 	tags: ContentItem<ITag>[]
+	/** Set automatically when the post is published to social media. */
+	socialPublishedDate?: string
 }


### PR DESCRIPTION
## Summary

Mixed bundle of in-progress work — all on one branch per request.

- **New `create-blog-post` skill** ([.claude/skills/create-blog-post/SKILL.md](.claude/skills/create-blog-post/SKILL.md)) — end-to-end workflow that uses the Agility MCP server to author a blog post in `en-us`, translate to `fr`, and upload a hero image. Outputs edit + preview URLs for both locales.
- **Fix French preview mode** — `/api/preview` was dropping the locale after `getDynamicPageURL()` returned a non-localized path, so `?lang=fr` preview URLs landed on the English version. Same fix in `/api/preview/exit`. Made `localizeUrl` idempotent so repeat calls don't produce `/fr/fr/...`.
- **Schema fix for `review-pr` skill** — added `name:` to frontmatter to satisfy the skill schema validator.
- **Social publishing integration** — Hootsuite provider, revalidate-webhook hook that fires publish on Post publish events, env var wiring, `socialPublishedDate` field on `IPost`.
- **Image recommendations doc** — editor + developer guidance for uploading and rendering images via Agility.

## Test plan

- [x] Open a Post preview URL with `?lang=fr` (e.g. the `/blog?ContentID=252&lang=fr&...` link) and confirm it lands on `/fr/blog/<slug>?preview=1` with the French translation rendered.
- [x] Open the same URL shape with `/fr/blog?...` and confirm it also lands correctly (no `/fr/fr/...` double-prefix).
- [x] Open an `en-us` preview and confirm it still works unchanged.
- [x] Exit preview from a French post — confirm it returns to `/fr/blog/<slug>`, not the English version.
- [x] Invoke the `create-blog-post` skill against the Demo Site 2026 instance with a test topic and confirm both locales save with matching `contentID` and correct linked content.
- [x] Publish a Post in the CMS and confirm the Hootsuite webhook fires (requires `HOOTSUITE_ACCESS_TOKEN`, `HOOTSUITE_PROFILE_IDS`, `AGILITY_API_MANAGEMENT_KEY`, `SITE_URL` env vars in the deployment env).
- [x] `npm run lint` + `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
