### PR TITLE
Clear sitemap cache on dynamic page content changes (publish, delete, unpublish)

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -40,7 +40,10 @@ export async function POST(req: NextRequest) {
 				apiKey
 			})
 
-			const languageCode = process.env.AGILITY_LOCALES || "en-us"
+			//use the locale of the item that changed (NOT the full AGILITY_LOCALES
+			//list) so the node lookup and path resolution happen in the right locale
+			const defaultLocale = process.env.AGILITY_LOCALES?.split(",")[0] || "en-us"
+			const languageCode = data.languageCode || defaultLocale
 
 			//don't cache the sitemap here... we want to get the latest
 			agilityClient.config.fetchConfig = {
@@ -72,6 +75,15 @@ export async function POST(req: NextRequest) {
 					revalidatePath(path)
 					console.info("Revalidating path:", path)
 
+					//this content item backs a dynamic page, so its change can alter the
+					//sitemap (new node, changed slug, removed node). Clear the sitemap tags
+					//so the flat/nested sitemaps (and anything that resolves URLs from them,
+					//e.g. the locale switcher) pick up the change immediately.
+					const sitemapTagFlat = `agility-sitemap-flat-${data.languageCode}`
+					const sitemapTagNested = `agility-sitemap-nested-${data.languageCode}`
+					revalidateTag(sitemapTagFlat)
+					revalidateTag(sitemapTagNested)
+					console.info("Revalidating sitemap tags (dynamic page item):", sitemapTagFlat, sitemapTagNested)
 				}
 			}
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -23,16 +23,35 @@ export async function POST(req: NextRequest) {
 	//parse the body
 	const data = await req.json() as IRevalidateRequest
 
+	//a publish makes content live; a delete/unpublish takes it offline. Both can
+	//change the sitemap (a node is added, renamed, or removed), so both need the
+	//sitemap cache cleared.
+	const isPublish = data.state === "Published"
+	const isRemoval = data.state === "Deleted" || data.state === "Unpublished"
 
-	//only process publish events
-	if (data.state === "Published") {
+	//helper: clear the flat + nested sitemap tags for a locale so anything that
+	//resolves URLs from the sitemap (the locale switcher, the blog listing,
+	//generateStaticParams) picks up the change immediately.
+	const revalidateSitemapTags = (locale?: string) => {
+		const sitemapTagFlat = `agility-sitemap-flat-${locale}`
+		const sitemapTagNested = `agility-sitemap-nested-${locale}`
+		revalidateTag(sitemapTagFlat)
+		revalidateTag(sitemapTagNested)
+		console.info("Revalidating sitemap tags:", sitemapTagFlat, sitemapTagNested)
+	}
+
+	const hasContentOrPage = !!data.referenceName || (data.pageID !== undefined && data.pageID > 0)
+
+	if ((isPublish || isRemoval) && hasContentOrPage) {
 
 		let sitemapFlat: {
 			[path: string]: SitemapNode
 		} = {}
 
-		//grab the sitemap flat so we can revalidate the full path if needed
-		if (data.contentID || data.pageID) {
+		//grab the sitemap flat so we can revalidate the full path if needed.
+		//only useful on publish: on a delete/unpublish the node is already gone
+		//from the sitemap, so there's nothing to look up.
+		if (isPublish && (data.contentID || data.pageID)) {
 			const apiKey = process.env.AGILITY_API_FETCH_KEY
 
 			const agilityClient = agilitySDK.getApi({
@@ -67,8 +86,8 @@ export async function POST(req: NextRequest) {
 
 			console.info("Revalidating content tags:", itemTag, listTag)
 
-			//grab the sitemap and check if this content is in there so we can revalidate a full path
-			if (sitemapFlat) {
+			if (isPublish) {
+				//grab the sitemap and check if this content is in there so we can revalidate a full path
 				const sitemapNode = Object.values(sitemapFlat).find(s => s.contentID === data.contentID)
 				if (sitemapNode) {
 					const path = sitemapNode.path
@@ -76,33 +95,29 @@ export async function POST(req: NextRequest) {
 					console.info("Revalidating path:", path)
 
 					//this content item backs a dynamic page, so its change can alter the
-					//sitemap (new node, changed slug, removed node). Clear the sitemap tags
-					//so the flat/nested sitemaps (and anything that resolves URLs from them,
-					//e.g. the locale switcher) pick up the change immediately.
-					const sitemapTagFlat = `agility-sitemap-flat-${data.languageCode}`
-					const sitemapTagNested = `agility-sitemap-nested-${data.languageCode}`
-					revalidateTag(sitemapTagFlat)
-					revalidateTag(sitemapTagNested)
-					console.info("Revalidating sitemap tags (dynamic page item):", sitemapTagFlat, sitemapTagNested)
+					//sitemap (new node, changed slug). Clear the sitemap tags so the
+					//flat/nested sitemaps pick up the change immediately.
+					revalidateSitemapTags(data.languageCode)
 				}
+			} else {
+				//delete/unpublish: if this was a dynamic page item, its node has been
+				//removed from the sitemap. We can't look it up anymore, so clear the
+				//sitemap tags so the removed node drops out right away.
+				revalidateSitemapTags(data.languageCode)
 			}
 
 
 		} else if (data.pageID !== undefined && data.pageID > 0) {
-			//page change
+			//page change or removal
 			const pageTag = `agility-page-${data.pageID}-${data.languageCode}`
 			revalidateTag(pageTag)
 
+			//a page being added, changed, or removed always affects the sitemap
+			revalidateSitemapTags(data.languageCode)
 
-			//also revalidate the sitemaps
-			const sitemapTagFlat = `agility-sitemap-flat-${data.languageCode}`
-			const sitemapTagNested = `agility-sitemap-nested-${data.languageCode}`
-			revalidateTag(sitemapTagFlat)
-			revalidateTag(sitemapTagNested)
+			console.info("Revalidating page tag:", pageTag)
 
-			console.info("Revalidating page and sitemap tags:", pageTag, sitemapTagFlat, sitemapTagNested)
-
-			if (sitemapFlat) {
+			if (isPublish) {
 				const sitemapNode = Object.values(sitemapFlat).find(s => s.pageID === data.pageID)
 				if (sitemapNode) {
 					const path = sitemapNode.path
@@ -112,8 +127,10 @@ export async function POST(req: NextRequest) {
 				}
 			}
 		}
-		// --- Social media auto-publish for blog posts ---
+
+		// --- Social media auto-publish for blog posts (publish only) ---
 		if (
+			isPublish &&
 			data.referenceName?.toLowerCase() === "posts" &&
 			data.contentID &&
 			data.languageCode


### PR DESCRIPTION
## Summary

Fixes the revalidate webhook (`src/app/api/revalidate/route.ts`) so the **sitemap cache is cleared whenever a page or dynamic page content item changes** — on publish, delete, and unpublish. Previously the sitemap could stay stale for up to its 60s TTL, so anything that resolves URLs from the sitemap (the locale switcher, the blog listing, `generateStaticParams`) lagged behind content changes.

## The gaps this closes

1. **Dynamic page content items didn't clear the sitemap.** A blog post publish arrives as a *content-item* change (`referenceName` + `contentID`). That branch only cleared the content tags + revalidated the node path — it never cleared the sitemap tags. So a new post, a renamed slug, or a removed post didn't show up until the TTL expired. Now, when the changed content item is found in the sitemap by `contentID` (i.e. it backs a dynamic page), the flat + nested sitemap tags for that locale are cleared too.

2. **Delete / unpublish events were ignored entirely.** The handler only acted on `"Published"`. Removing a page or dynamic page item also changes the sitemap (the node disappears), but nothing was revalidated. Now `"Deleted"` and `"Unpublished"` are handled alongside `"Published"`. On removal the node is already gone from the sitemap, so there's nothing to look up — the sitemap tags are cleared directly.

3. **Wrong locale for the sitemap fetch.** It used `process.env.AGILITY_LOCALES` (the comma-joined list `"en-us,fr"`) as the `languageCode`, so the node lookup ran against the wrong/single locale. It now uses the changed item's `data.languageCode` (falling back to the first configured locale).

## Behavior matrix

| Event | Content item (dynamic page) | Page |
|---|---|---|
| **Publish** | content tags + path + sitemap tags (if it's a sitemap node) | page tag + sitemap tags + path |
| **Delete / Unpublish** | content tags + sitemap tags | page tag + sitemap tags |

Repeated tag-clearing is factored into a `revalidateSitemapTags(locale)` helper.

## Preserved behavior
- The sitemap is only **fetched** on publish (where a node lookup can resolve a path) — no wasted fetch on removals.
- **Social auto-publish** stays gated to publish events only.
- The **URL-redirection rebuild-hook** branch (no content/page id) is intact.
- Non-live state changes (Staging / Approved / Awaiting Approval) are still ignored.

## Trade-off
On removal we can't tell whether the item was a dynamic-page item (its node is already gone), so a delete/unpublish of *any* content item now clears the sitemap tags. That's a single extra sitemap refetch in the rare non-page case — harmless, and the safe direction, since the cost of *not* clearing is a stale or 404'ing sitemap entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
