### PR TITLE
Improve SEO, AEO, performance, and best practices

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,33 @@ const nextConfig = {
 		viewTransition: true,
 		// ppr: true, // PPR requires Next.js canary - using manual Suspense pattern instead
 	},
+	poweredByHeader: false,
+	compress: true,
+	compiler: {
+		removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error", "warn"] } : false,
+	},
+	images: {
+		remotePatterns: [
+			{ protocol: "https", hostname: "**.agilitycms.com" },
+			{ protocol: "https", hostname: "cdn.agilitycms.com" },
+		],
+	},
+	async headers() {
+		return [
+			{
+				source: "/(.*)",
+				headers: [
+					{ key: "X-Content-Type-Options", value: "nosniff" },
+					{ key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+					{ key: "X-DNS-Prefetch-Control", value: "on" },
+					{
+						key: "Content-Security-Policy",
+						value: "frame-ancestors 'self' https://app.agilitycms.com;",
+					},
+				],
+			},
+		]
+	},
 }
 
 export default nextConfig

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,27 @@
+# Galaxy Tech
+
+> Galaxy Tech is a fictional demonstration brand built to showcase what you can create with Agility CMS (https://agilitycms.com). The site's messaging theme is the benefits of agility: moving fast, shipping sooner, adapting instantly to change, flexibility, and no lock-in. Nothing on this site is a real product, company, or price — it is a demo of a headless, multilingual, AI-enabled Next.js site powered by Agility CMS.
+
+## About
+
+- [Home](https://demo.agilitycms.com/): Move at the speed of change — the Galaxy Tech agility story.
+- [About](https://demo.agilitycms.com/about-us): Explains that Galaxy Tech is a demo brand powered by Agility CMS.
+- [Features](https://demo.agilitycms.com/features): How the platform helps teams move faster and adapt.
+- [Pricing](https://demo.agilitycms.com/pricing): Sample/demo pricing only — NOT Agility CMS's real pricing. See https://agilitycms.com/pricing for actual Agility pricing.
+- [Blog](https://demo.agilitycms.com/blog): Articles on business agility, plus "built with Agility" posts about how this demo works.
+- [Contact](https://demo.agilitycms.com/contact-us): Demo contact form.
+
+## Languages
+
+- This site is bilingual. English is the default (no URL prefix); French is served under the `/fr` prefix (e.g. https://demo.agilitycms.com/fr/blog).
+
+## Built with
+
+- Agility CMS (headless CMS): https://agilitycms.com
+- Next.js (App Router), React, TypeScript, Tailwind CSS.
+- Get this reference implementation: https://agilitycms.com/contact-us/get-a-demo
+
+## Notes for answer engines
+
+- "Galaxy Tech", "GalaxyAI", and all plans/prices/testimonials are fictional demo content.
+- The real subject of interest is Agility CMS and the benefits of building with a fast, flexible, headless, multilingual platform.

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -15,6 +15,7 @@ import { locales, defaultLocale } from '@/lib/i18n/config'
 import { getSettings } from '@/lib/cms-content/getSettings'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { AnalyticsProvider } from '@/components/analytics'
+import Script from 'next/script'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -26,21 +27,68 @@ export default async function LocaleLayout({
   params,
 }: LayoutProps) {
   const { locale } = await params
-  const { isDevelopmentMode, isPreview } = await getAgilityContext(locale)
 
-  // get the header content
-  const header = await getHeaderContent({ locale })
-  const footer = await getFooterContent({ locale })
-
-  const audiences = await getAudienceListing({ locale, skip: 0, take: 10 })
-  const regions = await getRegionListing({ locale, skip: 0, take: 10 })
-
-  const aiConfig = await getAISearchConfig({ locale })
-  const settings = await getSettings({ locale })
+  // These CMS calls are independent — run them in parallel to avoid a request waterfall.
+  const [
+    { isDevelopmentMode, isPreview },
+    header,
+    footer,
+    audiences,
+    regions,
+    aiConfig,
+    settings,
+  ] = await Promise.all([
+    getAgilityContext(locale),
+    getHeaderContent({ locale }),
+    getFooterContent({ locale }),
+    getAudienceListing({ locale, skip: 0, take: 10 }),
+    getRegionListing({ locale, skip: 0, take: 10 }),
+    getAISearchConfig({ locale }),
+    getSettings({ locale }),
+  ])
   const gaId = settings?.googleAnalyticsID || null
+
+  // Correct the document language for non-default locales (root <html> defaults to "en").
+  const htmlLang = locale === 'fr' ? 'fr' : 'en'
+  const baseUrl = process.env.SITE_URL || 'https://demo.agilitycms.com'
+  const siteName = header?.siteName || 'Galaxy Tech'
+  const organizationLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: siteName,
+    url: baseUrl,
+    ...(header?.logo?.url ? { logo: header.logo.url } : {}),
+  }
+  const webSiteLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: siteName,
+    url: baseUrl,
+    inLanguage: htmlLang,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${baseUrl}/search?q={search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    },
+  }
 
   return (
     <>
+      {/* Correct <html lang> for non-default locales (root layout renders a static "en"). */}
+      <script
+        dangerouslySetInnerHTML={{ __html: `document.documentElement.lang=${JSON.stringify(htmlLang)}` }}
+      />
+
+      {/* Site-wide structured data for search engines and answer engines. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteLd) }}
+      />
+
       {/* The Navbar (with the language switcher) is rendered by the page so it
           can use the current page's sitemap node for locale switching. */}
       {children}
@@ -69,6 +117,14 @@ export default async function LocaleLayout({
           {...{ isDevelopmentMode, isPreview, audiences, regions }}
         />
       </Suspense>
+
+      {/* Agility Web Studio SDK — load ONLY in preview/dev (in-context editing), never on the public production site. */}
+      {(isPreview || isDevelopmentMode) && (
+        <Script
+          src="https://unpkg.com/@agility/web-studio-sdk@latest/dist/index.js"
+          strategy="afterInteractive"
+        />
+      )}
     </>
   )
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,9 +1,6 @@
 import { algoliasearch } from 'algoliasearch'
 import { NextRequest } from 'next/server'
 
-// Initialize Algolia client
-const algolia = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_SEARCH_API_KEY!)
-
 export async function POST(req: NextRequest) {
 	try {
 		// Validate environment variables
@@ -14,6 +11,9 @@ export async function POST(req: NextRequest) {
 				{ status: 500 }
 			)
 		}
+
+		// Initialize Algolia client lazily (avoids throwing at import/build time when keys are absent)
+		const algolia = algoliasearch(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_SEARCH_API_KEY)
 
 		const { query, limit = 10 }: { query: string; limit?: number } = await req.json()
 

--- a/src/app/docs/CodeBlock.tsx
+++ b/src/app/docs/CodeBlock.tsx
@@ -1,9 +1,32 @@
 'use client'
 
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
+
+// Lazy-load react-syntax-highlighter (and its prism style objects) so this large
+// dependency is code-split out of the initial docs bundle and only loaded when a
+// code block actually renders. Each theme is baked into its own dynamic wrapper
+// so the style imports stay out of the initial bundle too.
+const makeSyntaxHighlighter = (styleName: 'vscDarkPlus' | 'oneLight') =>
+	dynamic(
+		async () => {
+			const [{ Prism }, styles] = await Promise.all([
+				import('react-syntax-highlighter'),
+				import('react-syntax-highlighter/dist/esm/styles/prism'),
+			])
+			const style = styles[styleName]
+			const P = Prism as any
+			const Highlighter = (props: Record<string, any>) => (
+				<P style={style} {...props} />
+			)
+			Highlighter.displayName = `SyntaxHighlighter(${styleName})`
+			return Highlighter
+		},
+		{ ssr: false, loading: () => null }
+	)
+
+const DarkSyntaxHighlighter = makeSyntaxHighlighter('vscDarkPlus')
+const LightSyntaxHighlighter = makeSyntaxHighlighter('oneLight')
 
 interface CodeBlockProps {
 	language: string
@@ -34,9 +57,10 @@ export function CodeBlock({ language, children, className, ...props }: CodeBlock
 		return () => observer.disconnect()
 	}, [])
 
+	const SyntaxHighlighter = isDark ? DarkSyntaxHighlighter : LightSyntaxHighlighter
+
 	return (
 		<SyntaxHighlighter
-			style={isDark ? vscDarkPlus : oneLight}
 			language={language}
 			PreTag="div"
 			className={`rounded-lg !mt-4 !mb-4 ${className || ''}`}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import '@/styles/view-transitions.css'
 
 import type { Metadata } from 'next'
 import type React from 'react'
-import Script from 'next/script'
 
 export const metadata: Metadata = {
   title: {
@@ -20,6 +19,9 @@ export default function RootLayout({
   return (
     <html lang="en" className="overflow-x-hidden" suppressHydrationWarning>
       <head>
+        <link rel="preconnect" href="https://api.fontshare.com" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://api.fontshare.com" />
+        <link rel="preconnect" href="https://cdn.agilitycms.com" />
         <link
           rel="stylesheet"
           href="https://api.fontshare.com/css?f%5B%5D=switzer@400,500,600,700&amp;display=swap"
@@ -48,8 +50,8 @@ export default function RootLayout({
         <main>
           {children}
         </main>
-        {/* Web Studio SDK */}
-        <Script src="https://unpkg.com/@agility/web-studio-sdk@latest/dist/index.js" />
+        {/* Agility Web Studio SDK is loaded (preview/dev only) from the [locale] layout,
+            so it never ships on the public production site. */}
       </body>
     </html>
   )

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,20 +1,23 @@
 # Algolia-Crawler-Verif: F3977A0FB53DDD41
 
 # Demo Site Robots Configuration
-# This demo site only allows indexing of the /docs section
-# In a production Agility CMS site, you would typically allow indexing of all pages
-# and generate the sitemap from Agility CMS pages via getSitemapFlat()
+# The full site is now indexable by search engines and AI crawlers.
+# The sitemap is generated from Agility CMS pages (via getSitemapFlat()) plus the demo /docs section.
 
 sitemap: https://demo.agilitycms.com/sitemap.xml
 
 User-agent: *
-# Disallow all pages except /docs
-Disallow: /
+Allow: /
 
-# Allow robots.txt and sitemap.xml to be accessed by search engines (must come after Disallow)
-Allow: /robots.txt
-Allow: /sitemap.xml
+# Explicitly allow AI crawlers to index the full site
+User-agent: GPTBot
+Allow: /
 
-# Allow only the /docs section
-Allow: /docs
-Allow: /docs/
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /

--- a/src/app/sitemap.tsx
+++ b/src/app/sitemap.tsx
@@ -1,70 +1,71 @@
+import { getSitemapFlat } from "@/lib/cms/getSitemapFlat";
 import { getAllDocFiles } from "@/lib/docs/getDocsFiles";
+import { locales, defaultLocale } from "@/lib/i18n/config";
 import type { MetadataRoute } from "next";
 
 /**
  * Demo Site Sitemap
  *
- * ⚠️ IMPORTANT: This sitemap is specific to this demo site and only includes /docs pages.
+ * This sitemap now covers BOTH:
+ * - All Agility CMS pages for every configured locale, generated via getSitemapFlat().
+ *   For the default locale, paths have no prefix; other locales are prefixed with /{locale}.
+ *   Folder nodes, redirects, and pages hidden from the sitemap are excluded.
+ * - The demo-site-specific /docs pages (generated from the local markdown files).
  *
- * In a REAL Agility CMS site:
- * - The /docs section would NOT exist (it's demo-site-specific)
- * - The sitemap would be generated from Agility CMS pages using getSitemapFlat()
- * - You would iterate through locales and generate entries for each page in the sitemap
- * - Example code (commented out below) shows the complete implementation for a real site
- *
- * Example for a real Agility CMS site:
- * ```typescript
- * import { getSitemapFlat } from "@/lib/cms/getSitemapFlat";
- * import { locales, defaultLocale } from "@/lib/i18n/config";
- *
- * export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
- *   const allSitemapEntries: MetadataRoute.Sitemap = [];
- *   const baseUrl = "https://your-site.com";
- *
- *   // Generate sitemap entries for each locale
- *   for (const locale of locales) {
- *     const sitemap = await getSitemapFlat({
- *       channelName: process.env.AGILITY_SITEMAP || "website",
- *       languageCode: locale
- *     });
- *
- *     if (!sitemap) continue;
- *
- *     const localeEntries = Object.keys(sitemap).filter((path) => {
- *       const node = sitemap[path];
- *       if (node.isFolder || node.redirect) {
- *         return false;
- *       }
- *
- *       if (!node.visible.sitemap) {
- *         return false;
- *       }
- *       return true;
- *     }).map((path, index) => {
- *       // For default locale, don't add locale prefix to URL
- *       const localizedPath = locale === defaultLocale ? path : `/${locale}${path}`;
- *
- *       return {
- *         url: index === 0 && path === "/" ? baseUrl : `${baseUrl}${localizedPath}`,
- *         lastModified: new Date(),
- *         changeFrequency: "daily" as const,
- *         priority: 1
- *       };
- *     });
- *
- *     allSitemapEntries.push(...localeEntries);
- *   }
- *
- *   return allSitemapEntries;
- * }
- * ```
+ * Note: the /docs section is specific to this demo site. In a real Agility CMS site
+ * the CMS pages portion (getSitemapFlat) would typically be the whole sitemap.
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	const baseUrl = "https://demo.agilitycms.com";
+	const baseUrl = process.env.SITE_URL || "https://demo.agilitycms.com";
+
+	// (a) Generate sitemap entries from Agility CMS pages, for each locale.
+	const cmsEntries: MetadataRoute.Sitemap = [];
+
+	for (const locale of locales) {
+		try {
+			const flatSitemap = await getSitemapFlat({
+				channelName: process.env.AGILITY_SITEMAP || "website",
+				languageCode: locale,
+			});
+
+			if (!flatSitemap) continue;
+
+			const localeEntries = Object.keys(flatSitemap)
+				.filter((path) => {
+					const node = flatSitemap[path];
+					if (node.isFolder || node.redirect) {
+						return false;
+					}
+					if (!node.visible?.sitemap) {
+						return false;
+					}
+					return true;
+				})
+				.map((path) => {
+					// For the default locale, don't add a locale prefix to the URL.
+					const localizedPath =
+						locale === defaultLocale ? path : `/${locale}${path}`;
+					const isHome = path === "/";
+
+					return {
+						url: isHome ? baseUrl : `${baseUrl}${localizedPath}`,
+						lastModified: new Date(),
+						changeFrequency: "daily" as const,
+						priority: isHome ? 1 : 0.8,
+					};
+				});
+
+			cmsEntries.push(...localeEntries);
+		} catch (error) {
+			// Guard each locale fetch so one failure doesn't break the whole sitemap.
+			console.error(`Failed to build sitemap for locale "${locale}":`, error);
+		}
+	}
+
+	// (b) Generate sitemap entries for documentation pages.
 	const docsEntries: MetadataRoute.Sitemap = [];
 	const addedPaths = new Set<string>();
 
-	// Generate sitemap entries for documentation pages
 	// This is demo-site-specific - in a real site, you'd generate from Agility CMS pages
 	const docFiles = getAllDocFiles();
 
@@ -111,5 +112,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		priority: 0.9
 	});
 
-	return docsEntries;
+	// Merge CMS page entries with the demo /docs entries.
+	return [...cmsEntries, ...docsEntries];
 }

--- a/src/components/agility-components/post-details/PostDetails.tsx
+++ b/src/components/agility-components/post-details/PostDetails.tsx
@@ -39,8 +39,47 @@ const PostDetails = async ({ dynamicPageItem, languageCode }: UnloadedModuleProp
 		? { ...post.image, label: decodeHtmlEntities(post.image.label) }
 		: post.image
 
+	// Build BlogPosting JSON-LD structured data, omitting any fields that are missing.
+	const baseUrl = process.env.SITE_URL || "https://demo.agilitycms.com"
+	const blogPostingStructuredData: Record<string, any> = {
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		publisher: {
+			"@type": "Organization",
+			name: "Galaxy Tech",
+		},
+	}
+	if (heading) {
+		blogPostingStructuredData.headline = heading
+	}
+	if (post.image?.url) {
+		blogPostingStructuredData.image = [post.image.url]
+	}
+	if (post.postDate) {
+		blogPostingStructuredData.datePublished = post.postDate
+	}
+	if (post.socialPublishedDate || post.postDate) {
+		blogPostingStructuredData.dateModified = post.socialPublishedDate || post.postDate
+	}
+	if (post.author?.fields?.name) {
+		blogPostingStructuredData.author = {
+			"@type": "Person",
+			name: post.author.fields.name,
+		}
+	}
+	if (post.slug) {
+		blogPostingStructuredData.mainEntityOfPage = {
+			"@type": "WebPage",
+			"@id": `${baseUrl}/blog/${post.slug}`,
+		}
+	}
+
 	return (
 		<Container data-agility-component={contentID}>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(blogPostingStructuredData) }}
+			/>
 			<Subheading
 				className="mt-16"
 				data-agility-field="postDate"

--- a/src/components/agility-components/pricing/FrequentlyAskedQuestions.tsx
+++ b/src/components/agility-components/pricing/FrequentlyAskedQuestions.tsx
@@ -37,8 +37,29 @@ export const FrequentlyAskedQuestions = async ({ module, languageCode }: Unloade
 
 	const faqs: IFAQ[] = faqsData.items.map((faq: ContentItem<IFAQ>) => faq.fields)
 
+	// Build FAQPage JSON-LD structured data. Answers may contain HTML, so strip tags.
+	const stripHtml = (html: string) =>
+		(html || "").replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim()
+
+	const faqStructuredData = {
+		"@context": "https://schema.org",
+		"@type": "FAQPage",
+		mainEntity: faqs.map((f) => ({
+			"@type": "Question",
+			name: f.question,
+			acceptedAnswer: {
+				"@type": "Answer",
+				text: stripHtml(f.answer),
+			},
+		})),
+	}
+
 	return (
 		<Container className='mt-20' data-agility-component={contentID}>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(faqStructuredData) }}
+			/>
 			<section id="faqs" className="scroll-mt-8">
 				<Subheading className="text-center" data-agility-field="subheading">
 					{subheading}

--- a/src/components/agility-components/pricing/PricingCards.tsx
+++ b/src/components/agility-components/pricing/PricingCards.tsx
@@ -81,8 +81,40 @@ export const PricingCards = async ({ module, languageCode, globalData }: Unloade
 			}
 		})
 
+	// Build Product JSON-LD structured data, one entry per pricing tier, omitting missing fields.
+	const baseUrl = process.env.SITE_URL || "https://demo.agilitycms.com"
+	const productsStructuredData = tiers.map((tier) => {
+		const offers: Record<string, any> = {
+			"@type": "Offer",
+			url: tier.ctaButton?.href || baseUrl,
+		}
+		if (tier.priceMonthly != null) {
+			offers.price = tier.priceMonthly
+		}
+		if (tier.currency) {
+			offers.priceCurrency = tier.currency
+		}
+
+		const product: Record<string, any> = {
+			"@context": "https://schema.org",
+			"@type": "Product",
+			offers,
+		}
+		if (tier.name) {
+			product.name = tier.name
+		}
+		if (tier.description) {
+			product.description = tier.description
+		}
+		return product
+	})
+
 	return (
 		<div className="relative py-24" data-agility-component={contentID}>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(productsStructuredData) }}
+			/>
 			<Gradient backgroundType='grays' className="absolute inset-x-2 top-48 bottom-0 rounded-4xl ring-1 ring-black/5 dark:ring-white/10 ring-inset" />
 			<Container className="relative">
 				{(title || subtitle) && (

--- a/src/components/ai-elements/code-block.tsx
+++ b/src/components/ai-elements/code-block.tsx
@@ -3,13 +3,33 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { CheckIcon, CopyIcon } from "lucide-react";
+import dynamic from "next/dynamic";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 import { createContext, useContext, useState } from "react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import {
-  oneDark,
-  oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
+
+// Lazy-load react-syntax-highlighter (and its prism style objects) so the large
+// highlighter/prism dependency is code-split out of the initial bundle and only
+// loaded when a code block actually renders. Each theme baked into its own
+// dynamic wrapper so the style import stays out of the initial bundle too.
+const makeSyntaxHighlighter = (styleName: "oneLight" | "oneDark") =>
+  dynamic(
+    async () => {
+      const [{ Prism }, styles] = await Promise.all([
+        import("react-syntax-highlighter"),
+        import("react-syntax-highlighter/dist/esm/styles/prism"),
+      ]);
+      const style = styles[styleName];
+      const Highlighter = (
+        props: ComponentProps<typeof Prism>
+      ) => <Prism style={style} {...props} />;
+      Highlighter.displayName = `SyntaxHighlighter(${styleName})`;
+      return Highlighter;
+    },
+    { ssr: false, loading: () => null }
+  );
+
+const LightSyntaxHighlighter = makeSyntaxHighlighter("oneLight");
+const DarkSyntaxHighlighter = makeSyntaxHighlighter("oneDark");
 
 type CodeBlockContextType = {
   code: string;
@@ -43,7 +63,7 @@ export const CodeBlock = ({
       {...props}
     >
       <div className="relative">
-        <SyntaxHighlighter
+        <LightSyntaxHighlighter
           className="overflow-hidden dark:hidden"
           codeTagProps={{
             className: "font-mono text-sm",
@@ -62,11 +82,10 @@ export const CodeBlock = ({
             minWidth: "2.5rem",
           }}
           showLineNumbers={showLineNumbers}
-          style={oneLight}
         >
           {code}
-        </SyntaxHighlighter>
-        <SyntaxHighlighter
+        </LightSyntaxHighlighter>
+        <DarkSyntaxHighlighter
           className="hidden overflow-hidden dark:block"
           codeTagProps={{
             className: "font-mono text-sm",
@@ -85,10 +104,9 @@ export const CodeBlock = ({
             minWidth: "2.5rem",
           }}
           showLineNumbers={showLineNumbers}
-          style={oneDark}
         >
           {code}
-        </SyntaxHighlighter>
+        </DarkSyntaxHighlighter>
         {children && (
           <div className="absolute top-2 right-2 flex items-center gap-2">
             {children}

--- a/src/components/ai-search/FloatingAISearch.tsx
+++ b/src/components/ai-search/FloatingAISearch.tsx
@@ -2,9 +2,17 @@
 
 import { SparklesIcon } from '@heroicons/react/24/solid'
 import { motion } from 'motion/react'
+import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
-import AIModal from './AIModal'
 import type { IAISearchConfigData } from '@/lib/cms-content/getAISearchConfig'
+
+// Lazy-load the AI modal tree (@ai-sdk, ai, streamdown, react-syntax-highlighter, etc.)
+// so it is not shipped in the initial bundle on every page. It is only mounted
+// once the modal is opened.
+const AIModal = dynamic(() => import('./AIModal'), {
+  ssr: false,
+  loading: () => null,
+})
 
 interface FloatingAISearchProps {
   aiConfig: IAISearchConfigData
@@ -63,12 +71,14 @@ export default function FloatingAISearch({ aiConfig }: FloatingAISearchProps) {
         </motion.button>
       </motion.div>
 
-      {/* AI Modal */}
-      <AIModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        aiConfig={aiConfig}
-      />
+      {/* AI Modal - only mounted (and its heavy deps loaded) once opened */}
+      {isModalOpen && (
+        <AIModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          aiConfig={aiConfig}
+        />
+      )}
     </>
   )
 }

--- a/src/lib/cms-content/resolveAgilityMetaData.ts
+++ b/src/lib/cms-content/resolveAgilityMetaData.ts
@@ -23,6 +23,13 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, parent }: Pr
 	const header = await getHeaderContent({ locale })
 	const ogImages = (await parent).openGraph?.images || []
 
+	//whether this dynamic page is a blog Post (drives openGraph.type + article fields)
+	let isPost = false
+	//article-specific openGraph fields, resolved from the Post content item when present
+	let publishedTime: string | undefined = undefined
+	let authors: string | undefined = undefined
+	let section: string | undefined = undefined
+
 	//#region *** resolve open graph stuff from dynamic pages ***
 	if (agilityData.sitemapNode.contentID !== undefined
 		&& agilityData.sitemapNode.contentID > 0) {
@@ -37,6 +44,8 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, parent }: Pr
 
 			if (contentItem.properties.definitionName === "Post") {
 				/* *** Posts MetaData *** */
+				isPost = true
+
 				const image = contentItem.fields["image"] as ImageField | undefined
 
 				if (image) {
@@ -44,6 +53,26 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, parent }: Pr
 						url: `${image.url}?format=auto&w=1200`,
 						alt: image.label
 					})
+				}
+
+				//reuse the already-fetched Post fields for article openGraph metadata (guard everything)
+				const postDate = (contentItem.fields["postDate"] ?? contentItem.fields["date"]) as string | undefined
+				if (postDate) publishedTime = new Date(postDate).toISOString()
+
+				const author = contentItem.fields["author"] as { fields?: { name?: string; title?: string } } | { name?: string } | string | undefined
+				if (typeof author === "string") {
+					if (author) authors = author
+				} else if (author) {
+					const authorName = ("fields" in author ? (author.fields?.name || author.fields?.title) : (author as { name?: string }).name)
+					if (authorName) authors = authorName
+				}
+
+				const category = contentItem.fields["category"] as { fields?: { title?: string; name?: string } } | { title?: string } | string | undefined
+				if (typeof category === "string") {
+					if (category) section = category
+				} else if (category) {
+					const categoryName = ("fields" in category ? (category.fields?.title || category.fields?.name) : (category as { title?: string }).title)
+					if (categoryName) section = categoryName
 				}
 			} else {
 				//TODO: handle other dynamic pages types here!
@@ -103,13 +132,70 @@ export const resolveAgilityMetaData = async ({ agilityData, locale, parent }: Pr
 
 
 
-	const metaData: Metadata = {
-		metadataBase: new URL('https://preview-tests-nov-2023.vercel.app'),
-		title: `${decodeHtmlEntities(agilityData.sitemapNode?.title)} | ${header?.siteName || "Company"}`,
-		description: agilityData.page?.seo?.metaDescription,
-		keywords: agilityData.page?.seo?.metaKeywords,
-		openGraph: {
+	//#region *** localized paths + resolved title/description ***
+	//NOTE: assumes slugs match across locales (en-us <-> fr). This is an acceptable
+	//fallback since we don't look up the matching localized sitemap node here.
+	const rawPath = agilityData.sitemapNode?.path
+	const path = (!rawPath || rawPath === "/") ? "" : rawPath
+	//en-us is the default locale and has no url prefix; fr is prefixed with /fr
+	const localizedPath = locale === "en-us" ? path : `/fr${path}`
+
+	const siteName = header?.siteName || "Galaxy Tech"
+
+	const title = `${decodeHtmlEntities(agilityData.sitemapNode?.title)} | ${siteName}`
+
+	const description = agilityData.page?.seo?.metaDescription
+		|| `${siteName} — move at the speed of change. A demo built with Agility CMS.`
+
+	const ogLocale = locale === "fr" ? "fr_CA" : "en_US"
+
+	//openGraph is a discriminated union on `type`, so branch on isPost to keep literal types
+	//and only attach the article-only fields (publishedTime/authors/section) for Posts.
+	const openGraph: Metadata["openGraph"] = isPost
+		? {
+			title,
+			description,
+			url: localizedPath || "/",
+			siteName,
+			type: "article",
+			locale: ogLocale,
 			images: ogImages,
+			...(publishedTime ? { publishedTime } : {}),
+			...(authors ? { authors } : {}),
+			...(section ? { section } : {}),
+		}
+		: {
+			title,
+			description,
+			url: localizedPath || "/",
+			siteName,
+			type: "website",
+			locale: ogLocale,
+			images: ogImages,
+		}
+	//#endregion
+
+	const metaData: Metadata = {
+		metadataBase: new URL(process.env.SITE_URL || "https://demo.agilitycms.com"),
+		title,
+		description,
+		keywords: agilityData.page?.seo?.metaKeywords,
+		alternates: {
+			//relative paths — Next resolves them against metadataBase
+			canonical: localizedPath || "/",
+			languages: {
+				"en-us": path || "/",
+				"fr": `/fr${path || ""}` || "/fr",
+				"x-default": path || "/",
+			},
+		},
+		openGraph,
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+			//ogImages elements can be a string, URL, or descriptor object — normalize to a url
+			images: ogImages.map((i) => (typeof i === "string" || i instanceof URL) ? i : i.url),
 		},
 
 		generator: `Agility CMS`,

--- a/src/lib/cms/getContentItem.ts
+++ b/src/lib/cms/getContentItem.ts
@@ -1,6 +1,7 @@
 import { type ContentItemRequestParams } from "@agility/content-fetch/dist/methods/getContentItem"
 import getAgilitySDK from "@/lib/cms/getAgilitySDK"
 import { type ContentItem } from "@agility/content-fetch"
+import { env } from "@/lib/env"
 
 /**
  * Get a content item with caching information added.
@@ -14,7 +15,7 @@ export const getContentItem = async <T>(params: ContentItemRequestParams) => {
 	agilitySDK.config.fetchConfig = {
 		next: {
 			tags: [`agility-content-${params.contentID}-${params.languageCode || params.locale}`],
-			revalidate: 60,
+			revalidate: env.AGILITY_FETCH_CACHE_DURATION,
 		},
 	}
 

--- a/src/lib/cms/getContentList.ts
+++ b/src/lib/cms/getContentList.ts
@@ -1,6 +1,7 @@
 import getAgilitySDK from "@/lib/cms/getAgilitySDK"
 import type { ContentListRequestParams } from "@agility/content-fetch/dist/methods/getContentList"
 import type { IContentListResponse } from "../types/IContentListResponse"
+import { env } from "@/lib/env"
 
 
 /**
@@ -16,7 +17,7 @@ export const getContentList = async <T>(params: ContentListRequestParams): Promi
 	agilitySDK.config.fetchConfig = {
 		next: {
 			tags: [`agility-content-${params.referenceName.toLowerCase()}-${params.languageCode || params.locale}`],
-			revalidate: 60,
+			revalidate: env.AGILITY_FETCH_CACHE_DURATION,
 		},
 	}
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -11,8 +11,6 @@ type RequiredEnvVars = {
 	AGILITY_SECURITY_KEY: string
 	AGILITY_LOCALES: string
 	AGILITY_SITEMAP: string
-	AGILITY_FETCH_CACHE_DURATION: string
-	AGILITY_PATH_REVALIDATE_DURATION: string
 
 	// PostHog
 	NEXT_PUBLIC_POSTHOG_KEY: string
@@ -31,6 +29,9 @@ type OptionalEnvVars = {
 	AGILITY_API_MANAGEMENT_KEY: string
 	// Site URL for building post links
 	SITE_URL: string
+	// Agility cache/revalidation durations (optional, default 60)
+	AGILITY_FETCH_CACHE_DURATION: string
+	AGILITY_PATH_REVALIDATE_DURATION: string
 }
 
 type EnvVars = RequiredEnvVars & Partial<OptionalEnvVars>
@@ -72,8 +73,6 @@ function getAllEnvVars(): EnvVars {
 		AGILITY_SECURITY_KEY: getRequiredEnvVar('AGILITY_SECURITY_KEY'),
 		AGILITY_LOCALES: getRequiredEnvVar('AGILITY_LOCALES'),
 		AGILITY_SITEMAP: getRequiredEnvVar('AGILITY_SITEMAP'),
-		AGILITY_FETCH_CACHE_DURATION: getRequiredEnvVar('AGILITY_FETCH_CACHE_DURATION'),
-		AGILITY_PATH_REVALIDATE_DURATION: getRequiredEnvVar('AGILITY_PATH_REVALIDATE_DURATION'),
 
 		// PostHog
 		NEXT_PUBLIC_POSTHOG_KEY: getRequiredEnvVar('NEXT_PUBLIC_POSTHOG_KEY'),
@@ -100,8 +99,8 @@ export const env = {
 	get AGILITY_SECURITY_KEY() { return getRequiredEnvVar('AGILITY_SECURITY_KEY') },
 	get AGILITY_LOCALES() { return getRequiredEnvVar('AGILITY_LOCALES') },
 	get AGILITY_SITEMAP() { return getRequiredEnvVar('AGILITY_SITEMAP') },
-	get AGILITY_FETCH_CACHE_DURATION() { return getRequiredEnvVar('AGILITY_FETCH_CACHE_DURATION') },
-	get AGILITY_PATH_REVALIDATE_DURATION() { return getRequiredEnvVar('AGILITY_PATH_REVALIDATE_DURATION') },
+	get AGILITY_FETCH_CACHE_DURATION() { return parseInt(process.env.AGILITY_FETCH_CACHE_DURATION || "60", 10) },
+	get AGILITY_PATH_REVALIDATE_DURATION() { return parseInt(process.env.AGILITY_PATH_REVALIDATE_DURATION || "60", 10) },
 	get NEXT_PUBLIC_POSTHOG_KEY() { return getRequiredEnvVar('NEXT_PUBLIC_POSTHOG_KEY') },
 	get NEXT_PUBLIC_POSTHOG_HOST() { return getRequiredEnvVar('NEXT_PUBLIC_POSTHOG_HOST') },
 	get NODE_ENV() { return getRequiredEnvVar('NODE_ENV') },


### PR DESCRIPTION
## Summary

A full technical pass over the site (perf, SEO, AEO, best practices), benchmarked against Agility's Next.js guidance. Content changes from the "benefits of agility / Galaxy Tech demo" rebrand were made in Agility CMS; **this PR is the code-side improvements only.**

Verified: `tsc --noEmit` clean, `next build` compiles successfully (`✓ Compiled successfully`).

## SEO / AEO
- **`resolveAgilityMetaData.ts`** — real `metadataBase` from `SITE_URL` (was a stale preview domain that broke every canonical/OG URL); added `alternates.canonical`, **hreflang** (`en-us`/`fr`/`x-default`), full **Open Graph** (title/description/type/url/siteName/locale) + **Twitter** cards, and **article** metadata (publishedTime/author/section) for blog posts.
- **`sitemap.tsx`** — full locale-aware sitemap from `getSitemapFlat` (all CMS pages, both locales, + docs). Previously emitted only `/docs`.
- **`robots.txt`** — opened to indexing incl. AI crawlers (GPTBot/ClaudeBot/PerplexityBot/Google-Extended); Algolia verification token preserved. *(Was `Disallow: /`.)*
- **JSON-LD structured data** — Organization + WebSite (site-wide, in the locale layout), FAQPage (pricing), BlogPosting (posts), Product/Offer (pricing tiers).
- **`public/llms.txt`** for answer-engine discoverability.
- Corrected **`<html lang>`** for `/fr` pages.

## Performance
- Lazy-loaded the **AI chat/search modal** tree and **react-syntax-highlighter** via `next/dynamic` (removes large libs from the initial bundle).
- **Agility Web Studio SDK** now loads in preview/dev only (was on every production page, unversioned from unpkg).
- Parallelized the locale layout's independent CMS calls with `Promise.all`; added font/CDN `preconnect` hints.

## Best practices / config
- **`next.config.mjs`** — security headers incl. `Content-Security-Policy: frame-ancestors 'self' https://app.agilitycms.com` (required for Web Studio; replaces X-Frame-Options), `poweredByHeader: false`, `compress`, `images.remotePatterns`, and `removeConsole` in production.
- Wired up the previously-unused `AGILITY_FETCH_CACHE_DURATION` / `AGILITY_PATH_REVALIDATE_DURATION` (made optional with defaults; consumed in `getContentItem`/`getContentList`).
- Lazy-init the Algolia client so the build no longer crashes when keys are absent.

## Notes / follow-ups (not included)
- `next/font` self-hosting of Switzer (needs the woff2 files; added `preconnect` instead).
- `contentLinkDepth: 0` for instant revalidation — skipped as it can affect nested-content rendering and needs testing.
- RSS feed route, `global-error.tsx`, multiple-`<h1>` refactor, PostHog consent gating — all P3.
- `next build` still stops at `/api/ai/agent` in an env-less sandbox (an AI-provider client initializes at import) — pre-existing/environmental; resolves with real env. Same lazy-init pattern as the Algolia fix would make it build-safe without keys.

> ⚠️ Opening `robots.txt` makes the fictional **Galaxy Tech** brand indexable by search + AI crawlers. Demo-brand disclaimers are in place, but revert that one change if the demo should stay out of search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPFnzH6QjJjjjorLwRdhh5)_